### PR TITLE
Fixes #99 for mantid_ipython_widget

### DIFF
--- a/addie/mantid_ipython_widget.py
+++ b/addie/mantid_ipython_widget.py
@@ -16,10 +16,10 @@ from pygments.lexer import RegexLexer
 # Monkeypatch!
 RegexLexer.get_tokens_unprocessed_unpatched = RegexLexer.get_tokens_unprocessed
 
-from IPython.qt.console.rich_ipython_widget import RichIPythonWidget
-#from qtconsole.rich_ipython_widget import RichIPythonWidget
-from IPython.qt.inprocess import QtInProcessKernelManager
-#import qtconsole.inprocess
+#from IPython.qt.console.rich_ipython_widget import RichIPythonWidget
+from qtconsole.rich_ipython_widget import RichIPythonWidget
+#from IPython.qt.inprocess import QtInProcessKernelManager
+import qtconsole.inprocess
 
 from mantid.api import AnalysisDataService as mtd
 


### PR DESCRIPTION
We need to do additional clean up of the hard-coded paths for Mantid