### PR TITLE
Make pyoncat optional

### DIFF
--- a/addie/master_table/import_from_run_number_handler.py
+++ b/addie/master_table/import_from_run_number_handler.py
@@ -3,8 +3,6 @@ from __future__ import (absolute_import, division, print_function)
 from qtpy.QtWidgets import QDialog
 from addie.utilities import load_ui
 
-from addie.master_table.import_from_database.oncat_authentication_handler import OncatAuthenticationHandler
-
 
 class ImportFromRunNumberHandler:
 
@@ -33,7 +31,7 @@ class ImportFromRunNumberWindow(QDialog):
         pass
 
     def change_user_clicked(self):
-        OncatAuthenticationHandler(parent=self.parent)
+        pass
 
     def run_number_return_pressed(self):
         pass

--- a/addie/master_table/table_tree_handler.py
+++ b/addie/master_table/table_tree_handler.py
@@ -19,8 +19,13 @@ from addie.master_table.import_table import ImportTable
 from addie.master_table.export_table import ExportTable
 from addie.master_table.master_table_loader import TableFileLoader
 from addie.master_table.master_table_exporter import TableFileExporter
-from addie.master_table.import_from_database.import_from_database_handler import ImportFromDatabaseHandler
-from addie.master_table.import_from_database.oncat_authentication_handler import OncatAuthenticationHandler
+try:
+    ONCAT_ENABLED = True
+    from addie.master_table.import_from_database.import_from_database_handler import ImportFromDatabaseHandler
+    from addie.master_table.import_from_database.oncat_authentication_handler import OncatAuthenticationHandler
+except ImportError:
+    print('pyoncat module not found. Functionality disabled')
+    ONCAT_ENABLED = False
 
 
 class TableInitialization:
@@ -544,10 +549,15 @@ class H3TableHandler:
         # Table
         table = menu.addMenu("Table")
 
-        table_import_from_database = table.addMenu("Import from Database")
-        table_import_from_database_replace = table_import_from_database.addAction("Replace ...")
-        table_import_from_database_append = table_import_from_database.addAction("Append ...")
-        table_import_from_database_append.setEnabled(self.parent.master_table_right_click_buttons['import_from_database_append']['status'])
+        if ONCAT_ENABLED:
+            table_import_from_database = table.addMenu("Import from Database")
+            table_import_from_database_replace = table_import_from_database.addAction("Replace ...")
+            table_import_from_database_append = table_import_from_database.addAction("Append ...")
+            table_import_from_database_append.setEnabled(self.parent.master_table_right_click_buttons['import_from_database_append']['status'])
+        else:
+            table_import_from_database = None
+            table_import_from_database_replace = None
+            table_import_from_database_append = None
 
         table_import_from_config = table.addMenu("Import from Config. File")
         table_import_from_config_replace = table_import_from_config.addAction("Replace ...")
@@ -636,7 +646,9 @@ class H3TableHandler:
         action = menu.exec_(QtGui.QCursor.pos())
 
         # selection
-        if action == activate_check_all:
+        if not action:
+            pass
+        elif action == activate_check_all:
             self.check_all()
         elif action == activate_uncheck_all:
             self.uncheck_all()

--- a/scripts/addie
+++ b/scripts/addie
@@ -85,7 +85,12 @@ from addie.master_table.reduction_configuration_handler import ReductionConfigur
 from addie.make_calibration_handler.make_calibration import MakeCalibrationLauncher
 from addie.master_table.periodic_table.material_handler import MaterialHandler
 from addie.master_table.mass_density_handler import MassDensityHandler
-from addie.master_table.import_from_database.import_from_database_handler import ImportFromDatabaseHandler
+try:
+    from addie.master_table.import_from_database.import_from_database_handler import ImportFromDatabaseHandler
+    ONCAT_ENABLED = True
+except ImportError:
+    print('pyoncat module not found. Functionality disabled')
+    ONCAT_ENABLED = False
 from addie.master_table.import_from_run_number_handler import ImportFromRunNumberHandler
 from addie.master_table.import_from_database.load_into_master_table import LoadIntoMasterTable
 
@@ -2779,7 +2784,10 @@ class MainWindow(QMainWindow):
         o_dimensions_ui.show()
 
     def launch_import_from_database_handler(self):
-        ImportFromDatabaseHandler(parent=self)
+        if ONCAT_ENABLED:
+            ImportFromDatabaseHandler(parent=self)
+        else:
+            print('oncat functionality disabled')
 
     def launch_import_from_run_number_handler(self):
         ImportFromRunNumberHandler(parent=self)


### PR DESCRIPTION
If the module is not found, there is a log message printed and gui elements go missing.