### PR TITLE
Fix addiedevel script for handling mantidqt import

### DIFF
--- a/addiedevel.sh
+++ b/addiedevel.sh
@@ -1,11 +1,21 @@
 #!/bin/sh
-python setup.py build
 
-PYTHON_VERSION=`python -c 'import sys; version=sys.version_info[:3]; print("{0}.{1}".format(*version))'`
+# select qt version
+if [ -n "${QT_API}" ]; then
+    LOCAL_QT_API=${QT_API}
+else
+    LOCAL_QT_API="pyqt5"
+fi
 
+# select the python to start with
 if [ $1 ]; then
     CMD=$1
 else
-    CMD=''
+    CMD="$(command -v mantidpythonnightly) --classic"
 fi
-PYTHONPATH=build/lib:$PYTHONPATH $CMD build/scripts-${PYTHON_VERSION}/addie
+
+PYTHON_VERSION=`$CMD -c 'import sys; version=sys.version_info[:3]; print("{0}.{1}".format(*version))'`
+$CMD setup.py build
+
+# launch addie
+QT_API=$LOCAL_QT_API PYTHONPATH=build/lib:$PYTHONPATH $CMD build/scripts-${PYTHON_VERSION}/addie

--- a/addiedevel.sh
+++ b/addiedevel.sh
@@ -8,8 +8,8 @@ else
 fi
 
 # select the python to start with
-if [ $1 ]; then
-    CMD=$1
+if [ -n "$1" ]; then
+    CMD="$@"
 else
     CMD="$(command -v mantidpythonnightly) --classic"
 fi


### PR DESCRIPTION
Changed `addiedevel.sh` script to fix import error for `mantidqt` module with mantid nightly.

To test, check that script launches for you successfully and nothing has changed to crash using this method. Two tests:
 - [ ] Does it work on my development machine?
 - [ ] Does it work on analysis?