### PR TITLE
Fix so rho in Calculate G(r) tab is passed to PDFFourierTransform

### DIFF
--- a/scripts/addie
+++ b/scripts/addie
@@ -737,9 +737,9 @@ class MainWindow(QMainWindow):
         else:
             raise RuntimeError('PDF filter {0} is not recognized.'.format(use_filter_str))
         rho0_str = str(self.ui.lineEdit_rho.text())
-        if rho0_str.isdigit():
-            rho0 = float(rho0_str)
-        else:
+        try:
+            rho0=float(rho0_str)
+        except ValueError:
             rho0 = None
 
         # PDF type


### PR DESCRIPTION
Uses a try-except to see if value is a float instead of `str.isdigit()`, which only works for integers.

This fixes the fact that `rho == None` no matter what.

To test, load S(Q) into `Calculate G(r)` tab, switch from `G(r)`->`g(r)`, adjust the rho value, click `Generate G(r)` to make one `g(r)`, then change `rho` vlaue and click `Generate G(r)` again. Make sure pattern changes accordingly.

Maybe advantageous to first merge #155 so test files are available in `tests/`.

Fixes #156 