### PR TITLE
Idl python sumscans

### DIFF
--- a/addie/processing/idl/run_sum_scans.py
+++ b/addie/processing/idl/run_sum_scans.py
@@ -6,7 +6,7 @@ from addie.processing.idl.step2_gui_handler import Step2GuiHandler
 
 class RunSumScans(object):
 
-    script = 'python  /SNS/users/zjn/pytest/sumscans.py '
+    script = 'python  /SNS/NOM/shared/autoNOM/stable/sumscans.py '
     output_file = ''
 
     def __init__(self, parent=None):

--- a/addie/processing/idl/run_sum_scans.py
+++ b/addie/processing/idl/run_sum_scans.py
@@ -6,7 +6,7 @@ from addie.processing.idl.step2_gui_handler import Step2GuiHandler
 
 class RunSumScans(object):
 
-    script = 'python  /SNS/NOM/shared/autoNOM/stable/sumscans.py '
+    script = 'python  /SNS/users/zjn/pytest/sumscans.py '
     output_file = ''
 
     def __init__(self, parent=None):
@@ -40,6 +40,8 @@ class RunSumScans(object):
 
         if not self.parent.interactive_mode_checkbox.isChecked():
             _script += "-n True"
+        if self.parent.pytest.isChecked():
+            _script += "-u True"
 
         qmax_list = str(self.parent.pdf_qmax_line_edit.text()).strip()
         if not (qmax_list == ""):

--- a/addie/ui/mainWindow.ui
+++ b/addie/ui/mainWindow.ui
@@ -59,7 +59,7 @@
          <x>0</x>
          <y>0</y>
          <width>1691</width>
-         <height>945</height>
+         <height>943</height>
         </rect>
        </property>
        <property name="minimumSize">
@@ -74,7 +74,7 @@
           <property name="orientation">
            <enum>Qt::Vertical</enum>
           </property>
-          <widget class="QWidget" name="">
+          <widget class="QWidget" name="layoutWidget">
            <layout class="QGridLayout" name="gridLayout_14">
             <item row="1" column="0">
              <widget class="QTabWidget" name="main_tab">
@@ -85,7 +85,7 @@
                </size>
               </property>
               <property name="currentIndex">
-               <number>4</number>
+               <number>1</number>
               </property>
               <widget class="QWidget" name="tab_5">
                <attribute name="title">
@@ -829,7 +829,7 @@
                 <item>
                  <widget class="QStackedWidget" name="stackedWidget">
                   <property name="currentIndex">
-                   <number>1</number>
+                   <number>0</number>
                   </property>
                   <widget class="QWidget" name="idl">
                    <layout class="QHBoxLayout" name="horizontalLayout_24">
@@ -1836,6 +1836,13 @@ p, li { white-space: pre-wrap; }
                                  </widget>
                                 </item>
                                </layout>
+                              </item>
+                              <item>
+                               <widget class="QCheckBox" name="pytest">
+                                <property name="text">
+                                 <string>Test</string>
+                                </property>
+                               </widget>
                               </item>
                               <item>
                                <spacer name="verticalSpacer">
@@ -4289,7 +4296,7 @@ p, li { white-space: pre-wrap; }
                   <property name="handleWidth">
                    <number>20</number>
                   </property>
-                  <widget class="QWidget" name="">
+                  <widget class="QWidget" name="layoutWidget">
                    <layout class="QVBoxLayout" name="verticalLayout_39">
                     <item>
                      <layout class="QHBoxLayout" name="horizontalLayout_73">
@@ -4746,7 +4753,7 @@ p, li { white-space: pre-wrap; }
                     </property>
                    </widget>
                   </widget>
-                  <widget class="QWidget" name="">
+                  <widget class="QWidget" name="layoutWidget">
                    <layout class="QVBoxLayout" name="verticalLayout_17">
                     <item>
                      <layout class="QVBoxLayout" name="verticalLayout_42">
@@ -5252,7 +5259,7 @@ p, li { white-space: pre-wrap; }
      <x>0</x>
      <y>0</y>
      <width>1711</width>
-     <height>20</height>
+     <height>22</height>
     </rect>
    </property>
    <property name="sizePolicy">
@@ -5638,8 +5645,8 @@ p, li { white-space: pre-wrap; }
    <slot>move_to_folder_clicked()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>55</x>
-     <y>90</y>
+     <x>69</x>
+     <y>115</y>
     </hint>
     <hint type="destinationlabel">
      <x>580</x>
@@ -5686,8 +5693,8 @@ p, li { white-space: pre-wrap; }
    <slot>manual_output_folder_field_edited()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>726</x>
-     <y>750</y>
+     <x>834</x>
+     <y>776</y>
     </hint>
     <hint type="destinationlabel">
      <x>580</x>
@@ -5766,8 +5773,8 @@ p, li { white-space: pre-wrap; }
    <slot>output_folder_radio_buttons()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>203</x>
-     <y>720</y>
+     <x>228</x>
+     <y>744</y>
     </hint>
     <hint type="destinationlabel">
      <x>580</x>
@@ -5782,8 +5789,8 @@ p, li { white-space: pre-wrap; }
    <slot>output_folder_radio_buttons()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>115</x>
-     <y>749</y>
+     <x>120</x>
+     <y>775</y>
     </hint>
     <hint type="destinationlabel">
      <x>580</x>
@@ -5798,8 +5805,8 @@ p, li { white-space: pre-wrap; }
    <slot>check_step2_gui()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>699</x>
-     <y>94</y>
+     <x>712</x>
+     <y>222</y>
     </hint>
     <hint type="destinationlabel">
      <x>656</x>
@@ -5814,8 +5821,8 @@ p, li { white-space: pre-wrap; }
    <slot>populate_table_clicked()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>897</x>
-     <y>93</y>
+     <x>1668</x>
+     <y>148</y>
     </hint>
     <hint type="destinationlabel">
      <x>580</x>
@@ -5831,7 +5838,7 @@ p, li { white-space: pre-wrap; }
    <hints>
     <hint type="sourcelabel">
      <x>163</x>
-     <y>122</y>
+     <y>435</y>
     </hint>
     <hint type="destinationlabel">
      <x>580</x>
@@ -5862,8 +5869,8 @@ p, li { white-space: pre-wrap; }
    <slot>background_combobox_changed()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>323</x>
-     <y>122</y>
+     <x>465</x>
+     <y>436</y>
     </hint>
     <hint type="destinationlabel">
      <x>580</x>
@@ -5895,7 +5902,7 @@ p, li { white-space: pre-wrap; }
    <hints>
     <hint type="sourcelabel">
      <x>1665</x>
-     <y>750</y>
+     <y>776</y>
     </hint>
     <hint type="destinationlabel">
      <x>1220</x>
@@ -5910,8 +5917,8 @@ p, li { white-space: pre-wrap; }
    <slot>table_right_click()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>631</x>
-     <y>94</y>
+     <x>644</x>
+     <y>222</y>
     </hint>
     <hint type="destinationlabel">
      <x>580</x>
@@ -5926,8 +5933,8 @@ p, li { white-space: pre-wrap; }
    <slot>check_plazcek_widgets()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>161</x>
-     <y>129</y>
+     <x>792</x>
+     <y>594</y>
     </hint>
     <hint type="destinationlabel">
      <x>580</x>
@@ -5942,8 +5949,8 @@ p, li { white-space: pre-wrap; }
    <slot>no_hidrogen_clicked()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>112</x>
-     <y>139</y>
+     <x>1019</x>
+     <y>560</y>
     </hint>
     <hint type="destinationlabel">
      <x>580</x>
@@ -5958,8 +5965,8 @@ p, li { white-space: pre-wrap; }
    <slot>reset_q_range()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>76</x>
-     <y>138</y>
+     <x>362</x>
+     <y>579</y>
     </hint>
     <hint type="destinationlabel">
      <x>5</x>
@@ -5974,8 +5981,8 @@ p, li { white-space: pre-wrap; }
    <slot>check_q_range()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>152</x>
-     <y>138</y>
+     <x>316</x>
+     <y>579</y>
     </hint>
     <hint type="destinationlabel">
      <x>6</x>
@@ -5990,8 +5997,8 @@ p, li { white-space: pre-wrap; }
    <slot>check_plazcek_widgets()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>155</x>
-     <y>129</y>
+     <x>725</x>
+     <y>594</y>
     </hint>
     <hint type="destinationlabel">
      <x>580</x>
@@ -6006,8 +6013,8 @@ p, li { white-space: pre-wrap; }
    <slot>check_fourier_filter_widgets()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>74</x>
-     <y>180</y>
+     <x>114</x>
+     <y>709</y>
     </hint>
     <hint type="destinationlabel">
      <x>580</x>
@@ -6022,8 +6029,8 @@ p, li { white-space: pre-wrap; }
    <slot>hidrogen_clicked()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>107</x>
-     <y>139</y>
+     <x>843</x>
+     <y>560</y>
     </hint>
     <hint type="destinationlabel">
      <x>580</x>
@@ -6038,8 +6045,8 @@ p, li { white-space: pre-wrap; }
    <slot>output_file_name_changed()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>218</x>
-     <y>133</y>
+     <x>973</x>
+     <y>862</y>
     </hint>
     <hint type="destinationlabel">
      <x>1028</x>
@@ -6054,8 +6061,8 @@ p, li { white-space: pre-wrap; }
    <slot>check_q_range()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>145</x>
-     <y>138</y>
+     <x>184</x>
+     <y>579</y>
     </hint>
     <hint type="destinationlabel">
      <x>3</x>
@@ -6070,8 +6077,8 @@ p, li { white-space: pre-wrap; }
    <slot>check_fourier_filter_widgets()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>74</x>
-     <y>180</y>
+     <x>540</x>
+     <y>709</y>
     </hint>
     <hint type="destinationlabel">
      <x>580</x>
@@ -6086,8 +6093,8 @@ p, li { white-space: pre-wrap; }
    <slot>run_ndabs_clicked()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>327</x>
-     <y>133</y>
+     <x>1313</x>
+     <y>862</y>
     </hint>
     <hint type="destinationlabel">
      <x>580</x>
@@ -6102,8 +6109,8 @@ p, li { white-space: pre-wrap; }
    <slot>run_sum_scans_clicked()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>205</x>
-     <y>124</y>
+     <x>1540</x>
+     <y>886</y>
     </hint>
     <hint type="destinationlabel">
      <x>1194</x>
@@ -6118,8 +6125,8 @@ p, li { white-space: pre-wrap; }
    <slot>pdf_qmax_line_edit_changed()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>250</x>
-     <y>148</y>
+     <x>1621</x>
+     <y>675</y>
     </hint>
     <hint type="destinationlabel">
      <x>1158</x>
@@ -6134,8 +6141,8 @@ p, li { white-space: pre-wrap; }
    <slot>export_table_clicked()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>91</x>
-     <y>93</y>
+     <x>519</x>
+     <y>148</y>
     </hint>
     <hint type="destinationlabel">
      <x>493</x>
@@ -6150,8 +6157,8 @@ p, li { white-space: pre-wrap; }
    <slot>sum_scans_output_file_name_changed()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>246</x>
-     <y>131</y>
+     <x>1612</x>
+     <y>824</y>
     </hint>
     <hint type="destinationlabel">
      <x>1103</x>
@@ -6182,8 +6189,8 @@ p, li { white-space: pre-wrap; }
    <slot>import_table_clicked()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>63</x>
-     <y>93</y>
+     <x>77</x>
+     <y>148</y>
     </hint>
     <hint type="destinationlabel">
      <x>243</x>
@@ -6214,8 +6221,8 @@ p, li { white-space: pre-wrap; }
    <slot>help_button_clicked_scans()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>279</x>
-     <y>124</y>
+     <x>1645</x>
+     <y>886</y>
     </hint>
     <hint type="destinationlabel">
      <x>915</x>
@@ -6230,8 +6237,8 @@ p, li { white-space: pre-wrap; }
    <slot>help_button_clicked_ndabs()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>100</x>
-     <y>133</y>
+     <x>1339</x>
+     <y>862</y>
     </hint>
     <hint type="destinationlabel">
      <x>966</x>
@@ -6278,8 +6285,8 @@ p, li { white-space: pre-wrap; }
    <slot>name_search_clicked()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>287</x>
-     <y>90</y>
+     <x>1642</x>
+     <y>115</y>
     </hint>
     <hint type="destinationlabel">
      <x>1356</x>
@@ -6294,8 +6301,8 @@ p, li { white-space: pre-wrap; }
    <slot>clear_name_search_clicked()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>126</x>
-     <y>90</y>
+     <x>1668</x>
+     <y>115</y>
     </hint>
     <hint type="destinationlabel">
      <x>1353</x>
@@ -6374,8 +6381,8 @@ p, li { white-space: pre-wrap; }
    <slot>reduction_configuration_button_clicked()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>210</x>
-     <y>858</y>
+     <x>233</x>
+     <y>887</y>
     </hint>
     <hint type="destinationlabel">
      <x>270</x>
@@ -6428,6 +6435,22 @@ p, li { white-space: pre-wrap; }
     <hint type="destinationlabel">
      <x>855</x>
      <y>503</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>pytest</sender>
+   <signal>clicked()</signal>
+   <receiver>MainWindow</receiver>
+   <slot>set_pytest()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>1407</x>
+     <y>757</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>1703</x>
+     <y>761</y>
     </hint>
    </hints>
   </connection>
@@ -6497,5 +6520,6 @@ p, li { white-space: pre-wrap; }
   <slot>reduction_configuration_button_clicked()</slot>
   <slot>browse_calibration_clicked()</slot>
   <slot>slot1()</slot>
+  <slot>set_pytest()</slot>
  </slots>
 </ui>

--- a/addie/ui/mainWindow.ui
+++ b/addie/ui/mainWindow.ui
@@ -5661,8 +5661,8 @@ p, li { white-space: pre-wrap; }
    <slot>vanadium_background_edited()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>610</x>
-     <y>263</y>
+     <x>130</x>
+     <y>109</y>
     </hint>
     <hint type="destinationlabel">
      <x>580</x>
@@ -5677,8 +5677,8 @@ p, li { white-space: pre-wrap; }
    <slot>diamond_background_edited()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>406</x>
-     <y>180</y>
+     <x>130</x>
+     <y>109</y>
     </hint>
     <hint type="destinationlabel">
      <x>580</x>
@@ -5693,8 +5693,8 @@ p, li { white-space: pre-wrap; }
    <slot>manual_output_folder_field_edited()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>834</x>
-     <y>776</y>
+     <x>130</x>
+     <y>125</y>
     </hint>
     <hint type="destinationlabel">
      <x>580</x>
@@ -5709,8 +5709,8 @@ p, li { white-space: pre-wrap; }
    <slot>sample_background_edited()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>610</x>
-     <y>294</y>
+     <x>130</x>
+     <y>109</y>
     </hint>
     <hint type="destinationlabel">
      <x>580</x>
@@ -5725,8 +5725,8 @@ p, li { white-space: pre-wrap; }
    <slot>run_autonom()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>838</x>
-     <y>905</y>
+     <x>130</x>
+     <y>129</y>
     </hint>
     <hint type="destinationlabel">
      <x>580</x>
@@ -5741,8 +5741,8 @@ p, li { white-space: pre-wrap; }
    <slot>vanadium_edited()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>610</x>
-     <y>232</y>
+     <x>130</x>
+     <y>109</y>
     </hint>
     <hint type="destinationlabel">
      <x>580</x>
@@ -5757,8 +5757,8 @@ p, li { white-space: pre-wrap; }
    <slot>select_current_folder_clicked()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>161</x>
-     <y>113</y>
+     <x>173</x>
+     <y>109</y>
     </hint>
     <hint type="destinationlabel">
      <x>594</x>
@@ -5773,8 +5773,8 @@ p, li { white-space: pre-wrap; }
    <slot>output_folder_radio_buttons()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>228</x>
-     <y>744</y>
+     <x>130</x>
+     <y>125</y>
     </hint>
     <hint type="destinationlabel">
      <x>580</x>
@@ -5789,8 +5789,8 @@ p, li { white-space: pre-wrap; }
    <slot>output_folder_radio_buttons()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>120</x>
-     <y>775</y>
+     <x>130</x>
+     <y>125</y>
     </hint>
     <hint type="destinationlabel">
      <x>580</x>
@@ -5838,7 +5838,7 @@ p, li { white-space: pre-wrap; }
    <hints>
     <hint type="sourcelabel">
      <x>163</x>
-     <y>435</y>
+     <y>434</y>
     </hint>
     <hint type="destinationlabel">
      <x>580</x>
@@ -5853,8 +5853,8 @@ p, li { white-space: pre-wrap; }
    <slot>diamond_edited()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>406</x>
-     <y>153</y>
+     <x>130</x>
+     <y>109</y>
     </hint>
     <hint type="destinationlabel">
      <x>580</x>
@@ -5869,8 +5869,8 @@ p, li { white-space: pre-wrap; }
    <slot>background_combobox_changed()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>465</x>
-     <y>436</y>
+     <x>607</x>
+     <y>435</y>
     </hint>
     <hint type="destinationlabel">
      <x>580</x>
@@ -5885,8 +5885,8 @@ p, li { white-space: pre-wrap; }
    <slot>create_new_autonom_folder_button_clicked()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>108</x>
-     <y>663</y>
+     <x>120</x>
+     <y>125</y>
     </hint>
     <hint type="destinationlabel">
      <x>83</x>
@@ -5901,8 +5901,8 @@ p, li { white-space: pre-wrap; }
    <slot>manual_output_folder_button_clicked()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>1665</x>
-     <y>776</y>
+     <x>130</x>
+     <y>125</y>
     </hint>
     <hint type="destinationlabel">
      <x>1220</x>
@@ -5934,7 +5934,7 @@ p, li { white-space: pre-wrap; }
    <hints>
     <hint type="sourcelabel">
      <x>792</x>
-     <y>594</y>
+     <y>593</y>
     </hint>
     <hint type="destinationlabel">
      <x>580</x>
@@ -5949,8 +5949,8 @@ p, li { white-space: pre-wrap; }
    <slot>no_hidrogen_clicked()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>1019</x>
-     <y>560</y>
+     <x>1107</x>
+     <y>559</y>
     </hint>
     <hint type="destinationlabel">
      <x>580</x>
@@ -5965,8 +5965,8 @@ p, li { white-space: pre-wrap; }
    <slot>reset_q_range()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>362</x>
-     <y>579</y>
+     <x>571</x>
+     <y>578</y>
     </hint>
     <hint type="destinationlabel">
      <x>5</x>
@@ -5982,7 +5982,7 @@ p, li { white-space: pre-wrap; }
    <hints>
     <hint type="sourcelabel">
      <x>316</x>
-     <y>579</y>
+     <y>578</y>
     </hint>
     <hint type="destinationlabel">
      <x>6</x>
@@ -5998,7 +5998,7 @@ p, li { white-space: pre-wrap; }
    <hints>
     <hint type="sourcelabel">
      <x>725</x>
-     <y>594</y>
+     <y>593</y>
     </hint>
     <hint type="destinationlabel">
      <x>580</x>
@@ -6013,8 +6013,8 @@ p, li { white-space: pre-wrap; }
    <slot>check_fourier_filter_widgets()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>114</x>
-     <y>709</y>
+     <x>154</x>
+     <y>708</y>
     </hint>
     <hint type="destinationlabel">
      <x>580</x>
@@ -6029,8 +6029,8 @@ p, li { white-space: pre-wrap; }
    <slot>hidrogen_clicked()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>843</x>
-     <y>560</y>
+     <x>937</x>
+     <y>559</y>
     </hint>
     <hint type="destinationlabel">
      <x>580</x>
@@ -6062,7 +6062,7 @@ p, li { white-space: pre-wrap; }
    <hints>
     <hint type="sourcelabel">
      <x>184</x>
-     <y>579</y>
+     <y>578</y>
     </hint>
     <hint type="destinationlabel">
      <x>3</x>
@@ -6077,8 +6077,8 @@ p, li { white-space: pre-wrap; }
    <slot>check_fourier_filter_widgets()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>540</x>
-     <y>709</y>
+     <x>912</x>
+     <y>708</y>
     </hint>
     <hint type="destinationlabel">
      <x>580</x>
@@ -6126,7 +6126,7 @@ p, li { white-space: pre-wrap; }
    <hints>
     <hint type="sourcelabel">
      <x>1621</x>
-     <y>675</y>
+     <y>674</y>
     </hint>
     <hint type="destinationlabel">
      <x>1158</x>
@@ -6173,8 +6173,8 @@ p, li { white-space: pre-wrap; }
    <slot>help_button_clicked()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>1678</x>
-     <y>905</y>
+     <x>50</x>
+     <y>129</y>
     </hint>
     <hint type="destinationlabel">
      <x>956</x>
@@ -6253,8 +6253,8 @@ p, li { white-space: pre-wrap; }
    <slot>create_exp_ini_clicked()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>105</x>
-     <y>905</y>
+     <x>117</x>
+     <y>129</y>
     </hint>
     <hint type="destinationlabel">
      <x>2</x>
@@ -6317,8 +6317,8 @@ p, li { white-space: pre-wrap; }
    <slot>personalization_table_clicked()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>1678</x>
-     <y>86</y>
+     <x>60</x>
+     <y>109</y>
     </hint>
     <hint type="destinationlabel">
      <x>1550</x>
@@ -6333,8 +6333,8 @@ p, li { white-space: pre-wrap; }
    <slot>h3_table_right_click()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>887</x>
-     <y>456</y>
+     <x>130</x>
+     <y>118</y>
     </hint>
     <hint type="destinationlabel">
      <x>1710</x>
@@ -6349,8 +6349,8 @@ p, li { white-space: pre-wrap; }
    <slot>table_search()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>696</x>
-     <y>91</y>
+     <x>230</x>
+     <y>109</y>
     </hint>
     <hint type="destinationlabel">
      <x>785</x>
@@ -6365,8 +6365,8 @@ p, li { white-space: pre-wrap; }
    <slot>table_search_clear()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>1092</x>
-     <y>94</y>
+     <x>60</x>
+     <y>109</y>
     </hint>
     <hint type="destinationlabel">
      <x>1146</x>
@@ -6381,8 +6381,8 @@ p, li { white-space: pre-wrap; }
    <slot>reduction_configuration_button_clicked()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>233</x>
-     <y>887</y>
+     <x>130</x>
+     <y>116</y>
     </hint>
     <hint type="destinationlabel">
      <x>270</x>
@@ -6397,8 +6397,8 @@ p, li { white-space: pre-wrap; }
    <slot>browse_calibration_clicked()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>519</x>
-     <y>871</y>
+     <x>130</x>
+     <y>116</y>
     </hint>
     <hint type="destinationlabel">
      <x>619</x>
@@ -6413,8 +6413,8 @@ p, li { white-space: pre-wrap; }
    <slot>make_calibration_clicked()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>709</x>
-     <y>883</y>
+     <x>130</x>
+     <y>116</y>
     </hint>
     <hint type="destinationlabel">
      <x>847</x>
@@ -6435,22 +6435,6 @@ p, li { white-space: pre-wrap; }
     <hint type="destinationlabel">
      <x>855</x>
      <y>503</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>pytest</sender>
-   <signal>clicked()</signal>
-   <receiver>MainWindow</receiver>
-   <slot>set_pytest()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>1407</x>
-     <y>757</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>1703</x>
-     <y>761</y>
     </hint>
    </hints>
   </connection>

--- a/addiedevel.sh
+++ b/addiedevel.sh
@@ -20,4 +20,4 @@ PYTHON_VERSION=`$CMD -c 'import sys; version=sys.version_info[:3]; print("{0}.{1
 $CMD setup.py build
 
 # launch addie
-QT_API=$LOCAL_QT_API PYTHONPATH=build/lib:$PYTHONPATH $CMD build/scripts-${PYTHON_VERSION}/addie --mode 'idl'
+QT_API=$LOCAL_QT_API PYTHONPATH=build/lib:$PYTHONPATH $CMD build/scripts-${PYTHON_VERSION}/addie

--- a/addiedevel.sh
+++ b/addiedevel.sh
@@ -20,4 +20,4 @@ PYTHON_VERSION=`$CMD -c 'import sys; version=sys.version_info[:3]; print("{0}.{1
 $CMD setup.py build
 
 # launch addie
-QT_API=$LOCAL_QT_API PYTHONPATH=build/lib:$PYTHONPATH $CMD build/scripts-${PYTHON_VERSION}/addie
+QT_API=$LOCAL_QT_API PYTHONPATH=build/lib:$PYTHONPATH $CMD build/scripts-${PYTHON_VERSION}/addie --mode 'idl'

--- a/scripts/addie
+++ b/scripts/addie
@@ -309,7 +309,7 @@ class MainWindow(QMainWindow):
     o_help_scans = None
     o_help_mantid = None
 
-    def __init__(self, parent=None, processing_mode):
+    def __init__(self, parent=None, processing_mode=None):
         """ Initialization
         Parameters
         ----------

--- a/scripts/addie
+++ b/scripts/addie
@@ -327,7 +327,7 @@ class MainWindow(QMainWindow):
         self.ui.graphicsView_sq.set_main(self)
 
 	# Set the post-processing mode
-    	self.post_processing = processing_mode  # mantid or 'idl'
+	self.post_processing = processing_mode  # mantid or 'idl'
 
         # set widgets
         self.init_parameters()

--- a/scripts/addie
+++ b/scripts/addie
@@ -275,7 +275,6 @@ class MainWindow(QMainWindow):
     undo_index = max_undo_list
     undo_button_enabled = False
     redo_button_enabled = False
-    post_processing = 'mantid'  # or 'idl'
 
     debugging = False
     load_intermediate_step_ok = False
@@ -310,7 +309,7 @@ class MainWindow(QMainWindow):
     o_help_scans = None
     o_help_mantid = None
 
-    def __init__(self, parent=None):
+    def __init__(self, options, parent=None):
         """ Initialization
         Parameters
         ----------
@@ -326,6 +325,9 @@ class MainWindow(QMainWindow):
         self._promote_widgets()
 
         self.ui.graphicsView_sq.set_main(self)
+
+	# Set the post-processing mode
+    	self.post_processing = options.mode  # mantid or 'idl'
 
         # set widgets
         self.init_parameters()
@@ -2871,13 +2873,13 @@ class MainWindow(QMainWindow):
         ReductionConfigurationHandler(parent=self)
 
 
-def main():
+def main(options):
     app = QApplication(sys.argv)
     app.setOrganizationName("Qtrac Ltd.")
     app.setOrganizationDomain("qtrac.eu")
     app.setApplicationName("Image Changer")
     app.setWindowIcon(QIcon(":/icon.png"))
-    form = MainWindow()
+    form = MainWindow(options)
     form.show()
     app.exec_()
 
@@ -2885,6 +2887,7 @@ if __name__ == '__main__':
     import argparse  # noqa
     parser = argparse.ArgumentParser(description='ADvanced DIffraction Environment')
     parser.add_argument('--version', action='version', version='%(prog)s version {}'.format(__version__))
+    parser.add_argument('--mode', type=str, default='mantid')
 
     try:
         # set up bash completion as a soft dependency
@@ -2897,4 +2900,4 @@ if __name__ == '__main__':
     options = parser.parse_args()
 
     # start the main program
-    main()
+    main(options)

--- a/scripts/addie
+++ b/scripts/addie
@@ -309,7 +309,7 @@ class MainWindow(QMainWindow):
     o_help_scans = None
     o_help_mantid = None
 
-    def __init__(self, options, parent=None):
+    def __init__(self, parent=None, processing_mode):
         """ Initialization
         Parameters
         ----------
@@ -327,7 +327,7 @@ class MainWindow(QMainWindow):
         self.ui.graphicsView_sq.set_main(self)
 
 	# Set the post-processing mode
-    	self.post_processing = options.mode  # mantid or 'idl'
+    	self.post_processing = processing_mode  # mantid or 'idl'
 
         # set widgets
         self.init_parameters()
@@ -2873,13 +2873,13 @@ class MainWindow(QMainWindow):
         ReductionConfigurationHandler(parent=self)
 
 
-def main(options):
+def main(mode):
     app = QApplication(sys.argv)
     app.setOrganizationName("Qtrac Ltd.")
     app.setOrganizationDomain("qtrac.eu")
     app.setApplicationName("Image Changer")
     app.setWindowIcon(QIcon(":/icon.png"))
-    form = MainWindow(options)
+    form = MainWindow(processing_mode=mode)
     form.show()
     app.exec_()
 
@@ -2887,7 +2887,8 @@ if __name__ == '__main__':
     import argparse  # noqa
     parser = argparse.ArgumentParser(description='ADvanced DIffraction Environment')
     parser.add_argument('--version', action='version', version='%(prog)s version {}'.format(__version__))
-    parser.add_argument('--mode', type=str, default='mantid')
+    parser.add_argument('--mode', type=str, default='mantid',
+			help='Set processing mode ((default=%default)s)', choices=['mantid', 'idl'])
 
     try:
         # set up bash completion as a soft dependency
@@ -2900,4 +2901,4 @@ if __name__ == '__main__':
     options = parser.parse_args()
 
     # start the main program
-    main(options)
+    main(options.mode)

--- a/scripts/addie
+++ b/scripts/addie
@@ -325,9 +325,9 @@ class MainWindow(QMainWindow):
         self._promote_widgets()
 
         self.ui.graphicsView_sq.set_main(self)
-
-	# Set the post-processing mode
-	self.post_processing = processing_mode  # mantid or 'idl'
+        
+        # Set the post-processing mode
+        self.post_processing = processing_mode  # mantid or 'idl'
 
         # set widgets
         self.init_parameters()

--- a/scripts/addie
+++ b/scripts/addie
@@ -2888,7 +2888,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='ADvanced DIffraction Environment')
     parser.add_argument('--version', action='version', version='%(prog)s version {}'.format(__version__))
     parser.add_argument('--mode', type=str, default='mantid',
-			help='Set processing mode ((default=%default)s)', choices=['mantid', 'idl'])
+			help='Set processing mode (default=%(default)s)', choices=['mantid', 'idl'])
 
     try:
         # set up bash completion as a soft dependency


### PR DESCRIPTION
**IDL post-processing**
- Initial work for the IDL script paths (not hooked up yet)
- Adds the Python version of sumscans as a checkbox
- Adds `--mode <mantid, idl>` options for arguments to start up in either mode automatically

**To test:**
- Go to `File -> Settings` and switch between `Mantid` and `IDL`. Should see that a group box appears for the `IDL` option but not Mantid.
- We processed some data and found a bug in the underlying SumScans script but the checkbox in `addie` only adds a flag for this script so little to test on our (`addie`) side except that it launches without the IDL plotting (only can run on analysis.sns.gov).
- Launch using `./addiedevel.sh` but with the added `--mode` option (must hard-code in that script for now since $1 is set for the mantidpython path) to check that you can start from IDL post-procesing or mantid post-processing. 