### PR TITLE
Move flake8 configuration into canonical place

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,0 @@
-[flake8]
-ignore = E114,E115,E116,E121,E123,E126,E133,E2,E704,E722,E741,E743,W503,F403,F405,F999
-exclude = addie/icons/icons_rc.py,versioneer.py
-doctests = True
-max-line-length = 130

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,12 @@ doc_files = README.md
 # re-run 'versioneer.py setup' after changing this section, and commit the
 # resulting files.
 
+[flake8]
+ignore = E114,E115,E116,E121,E123,E126,E133,E2,E704,E722,E741,E743,W503,F403,F405,F999
+exclude = addie/icons/icons_rc.py,versioneer.py
+doctests = True
+max-line-length = 130
+
 [versioneer]
 VCS = git
 style = pep440


### PR DESCRIPTION
I recently discovered that the "normal" place to put flake8 configuration is in `setup.cfg`. This moves it to there.