### PR TITLE
Added configparser to conda recipe

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -13,6 +13,7 @@ build:
 
 requirements:
   build:
+    - configparser
     - mantid-total-scattering-python-wrapper
     - mantid-workbench
     - periodictable
@@ -21,6 +22,7 @@ requirements:
     - setuptools
 
   run:
+    - configparser
     - mantid-total-scattering-python-wrapper
     - mantid-workbench
     - periodictable


### PR DESCRIPTION
Fixes #236, simply adds `configparser` to conda recipe for the Python 2.7 package.

**To Test**
Will test after merge into `master` and deployment.