### PR TITLE
Users shouldn't rename the reduction property manager

### DIFF
--- a/addie/config.json
+++ b/addie/config.json
@@ -15,7 +15,8 @@
     "Dspacing",
     "UnwrapRef",
     "LowResRef",
-    "LowResSpectrumOffset"
+    "LowResSpectrumOffset",
+    "ReductionProperties"
   ],
   "pdf": {
     "q_range": {


### PR DESCRIPTION
Quick usability improvement noticed during this morning's meeting.