### PR TITLE
Pin conda build to version 3.17.x since bug in 3.18.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ install:
   conda info -a
 
   # Activate environment
-  conda create -q -n addie_env python=$CONDA flake8 conda-build conda-verify anaconda-client
+  conda create -q -n addie_env python=$CONDA flake8 conda-build=3.17 conda-verify anaconda-client
   source activate addie_env
 
   # Build recipe and install addie


### PR DESCRIPTION
This is to see if we can get around the `Pickle` bug that popped up in Travis-CI builds: 

https://travis-ci.org/neutrons/addie/jobs/537842351#L2652-L2655

Conda change log for 3.18.2:

https://github.com/conda/conda-build/blob/master/CHANGELOG.txt
