### PR TITLE
Add geometry JSON processing for reduction-ready input

### DIFF
--- a/addie/processing/mantid/master_table/geometry_handler.py
+++ b/addie/processing/mantid/master_table/geometry_handler.py
@@ -10,6 +10,43 @@ from addie.utilities.math_tools import is_number
 from addie.processing.mantid.master_table.tree_definition import INDEX_OF_COLUMNS_WITH_GEOMETRY_INFOS
 
 
+def _sphere_csg_radius(value):
+    value = 0.01 * value  # converts from cm -> m for CSG
+    sphere_xml = " \
+        <sphere id='some-sphere'> \
+            <centre x='0.0'  y='0.0' z='0.0' /> \
+            <radius val={radius} /> \
+        </sphere> \
+        <algebra val='some-sphere' /> \
+    ".format(radius=value)
+    return sphere_xml
+
+
+_table2mantid_cylinder = {
+    "Shape": {"Key": "Shape"},
+    "Radius": {"Key": "Radius"},
+    "Height": {"Key": "Height"}
+}
+
+_table2mantid_hollow_cylinder = {
+    "Shape": {"Key": "Shape", "ValueProcessor": lambda x: "HollowCylinder"},
+    "Radius": {"Key": "InnerRadius"},
+    "Radius2": {"Key": "OuterRadius"},
+    "Height": {"Key": "Height"}
+}
+
+_table2mantid_sphere = {
+    "Shape": {"Key": "Shape", "ValueProcessor": lambda x: "CSG"},
+    "Radius": {"Key": "Value", "ValueProcessor": _sphere_csg_radius}
+}
+
+table2mantid = {
+    "Cylinder": _table2mantid_cylinder,
+    "Hollow Cylinder": _table2mantid_hollow_cylinder,
+    "Sphere": _table2mantid_sphere
+}
+
+
 class DimensionsSetter(QDialog):
 
     shape_selected = 'Cylinder'
@@ -18,7 +55,7 @@ class DimensionsSetter(QDialog):
     def __init__(self, parent=None, key=None, data_type='sample'):
         self.parent = parent
         self.key = key
-        self.data_type =  data_type
+        self.data_type = data_type
 
         QDialog.__init__(self, parent=parent)
         self.ui = load_ui('dimensions_setter.ui', baseinstance=self)
@@ -54,7 +91,8 @@ class DimensionsSetter(QDialog):
         :argument:
         geometry_type being 'radius', 'radius2' or 'height'
         '''
-        return str(self.parent.master_table_list_ui[self.key][self.data_type]['geometry'][geometry_type]['value'].text())
+        return str(self.parent.master_table_list_ui[self.key]
+                   [self.data_type]['geometry'][geometry_type]['value'].text())
 
     def __set_label_value(self, geometry_type, value):
         '''helper function to set value of label in master table.
@@ -63,7 +101,8 @@ class DimensionsSetter(QDialog):
         geometry_type being 'radius', 'radius2' or 'height'
         value: value to set
         '''
-        self.parent.master_table_list_ui[self.key][self.data_type]['geometry'][geometry_type]['value'].setText(value)
+        self.parent.master_table_list_ui[self.key][self.data_type]['geometry'][geometry_type]['value'].setText(
+            value)
 
     def init_widgets_content(self):
         '''populate the widgets using the value from the master table'''
@@ -102,7 +141,8 @@ class DimensionsSetter(QDialog):
             for _widget in self.group['radius2']:
                 _widget.setVisible(False)
             # display right image label
-            self.ui.preview.setPixmap(QtGui.QPixmap(":/preview/cylinder_reference.png"))
+            self.ui.preview.setPixmap(QtGui.QPixmap(
+                ":/preview/cylinder_reference.png"))
             self.ui.preview.setScaledContents(True)
 
         elif self.shape_selected.lower() == 'sphere':
@@ -115,12 +155,14 @@ class DimensionsSetter(QDialog):
             for _widget in self.group['height']:
                 _widget.setVisible(False)
             # display the right image label
-            self.ui.preview.setPixmap(QtGui.QPixmap(":/preview/sphere_reference.png"))
+            self.ui.preview.setPixmap(QtGui.QPixmap(
+                ":/preview/sphere_reference.png"))
             self.ui.preview.setScaledContents(True)
 
         elif self.shape_selected.lower() == 'hollow cylinder':
             # display the right image label
-            self.ui.preview.setPixmap(QtGui.QPixmap(":/preview/hollow_cylinder_reference.png"))
+            self.ui.preview.setPixmap(QtGui.QPixmap(
+                ":/preview/hollow_cylinder_reference.png"))
             self.ui.preview.setScaledContents(True)
 
         # display value of radius1,2,height for this row
@@ -168,7 +210,8 @@ class DimensionsSetter(QDialog):
         self.__set_label_value('height', height)
 
         o_table = TableRowHandler(main_window=self.parent)
-        o_table.transfer_widget_states(from_key=self.key, data_type=self.data_type)
+        o_table.transfer_widget_states(
+            from_key=self.key, data_type=self.data_type)
 
         self.parent.check_master_table_column_highlighting(column=self.column)
 

--- a/addie/processing/mantid/master_table/master_table_exporter.py
+++ b/addie/processing/mantid/master_table/master_table_exporter.py
@@ -498,10 +498,103 @@ class TableFileExporter:
 
         return dictionary
 
+    def _remove_keys_from_with_nan_values(self, dictionary, selected_values=None):
+        """Remove keys in a dictionary if the value is NaN
+
+        :param dictionary: Dictionary with keys we want to check
+        :type dictionary: dict
+        :param selected_values: Dictionary with keys we want to check
+        :type dictionary: dict
+
+        :return: Dictionary with keys removed where value is NaN
+        :rtype: dict
+        """
+        # Set default to check all keys unless selected_values defined
+        if selected_values is None:
+            selected_values = list(dictionary.keys()).copy()
+
+        # Warn if selected_values is not a proper subset of the keys in the dict
+        if not set(selected_values).issubset(dictionary.keys()):
+            err_string = "Found keys that are not part dictionary\n"
+            err_string +="  List with 'erroneous' key: {} \n".format(",".join(selected_values))
+            err_string +="  Dictionary keys: {} \n".format(",".join(dictionary.keys()))
+            raise Exception(err_string)
+
+        # Remove keys with NaN values
+        for key in selected_values:
+            try:
+                if np.isnan(dictionary[key]):
+                    dictionary.pop(key)
+            except TypeError:
+                pass
+
+        return dictionary
+
+    def geometry_selection_for_reduction(self, dictionary):
+        """Processing of the pre-reduction JSON's `Geometry` to return
+        a reduction-ready `Geometry` section in the passed dictionary
+
+        :param dictionary: Pre-reduction JSON with preliminary `Geometry` section
+        :type row: dict
+
+        :return: JSON dictionary with reduction-ready `Geometry` section
+        :rtype: dict
+        """
+        # Default value for geometry
+        geometry = {'Shape': 'Cylinder', 'Radius': 1.0}
+
+        # return a default geometry if not specified
+        if 'Geometry' not in dictionary:
+            dictionary['Geometry'] = geometry
+            print("No Geometry found, defaul geometry added:", geometry)
+            return dictionary
+
+        # Remove all NaN values from Geometry
+        dictionary['Geometry'] = self._remove_keys_from_with_nan_values(dictionary['Geometry'])
+
+        # return if no shape in Geometry, will use default in Mantid
+        if 'Shape' not in dictionary['Geometry']:    
+            return dictionary
+
+        # Get shapes
+        geometry = dictionary['Geometry']
+
+        """
+        if density['UseNumberDensity']:
+            mass_density = self._get_mass_density_from_number_density(
+                dictionary)
+
+        if density['UseMass']:
+            mass_density = self._get_mass_density_from_mass(dictionary)
+
+        # Post-process for output: take out overall Density and add MassDensity
+        # key
+        dictionary.pop('Density')
+        dictionary['MassDensity'] = mass_density
+        """
+
+        return dictionary
+
+
     def convert_from_row_to_reduction(self, json_input):
+        """Processing of the pre-reduction JSON's `Density` to return
+        a reduction-ready `MassDensity` section in the passed dictionary
+
+        :param dictionary: Pre-reduction JSON with preliminary `Density` section
+        :type row: dict
+
+        :return: JSON dictionary with reduction-ready `MassDensity` section
+        :rtype: dict
+        """
         reduction_input = json_input
-        print("\n\nBefore Reduction row:", reduction_input["Sample"])
-        print("\n\nAfter Reduction row:",
-              self.density_selection_for_reduction(reduction_input["Sample"]))
+        for element in ["Sample", "Normalization"]:
+            print("\n\n*** ", element, " ***\n\n")
+            element_section = reduction_input[element]
+            print("\n\nBefore Reduction row:", reduction_input[element])
+            element_section = self.density_selection_for_reduction(element_section)
+            self.geometry_selection_for_reduction(element_section)
+            print("\n\nAfter Reduction row:", reduction_input[element])
+
+        print("\n\n")
 
         return reduction_input

--- a/addie/processing/mantid/master_table/master_table_exporter.py
+++ b/addie/processing/mantid/master_table/master_table_exporter.py
@@ -7,6 +7,7 @@ import os
 
 from qtpy.QtCore import Qt
 
+from addie.processing.mantid.master_table.geometry_handler import table2mantid
 from addie.processing.mantid.master_table.periodic_table.material_handler import \
     retrieving_molecular_mass_and_number_of_atoms_worked
 from addie.processing.mantid.master_table.tree_definition import SAMPLE_FIRST_COLUMN, NORMALIZATION_FIRST_COLUMN
@@ -65,9 +66,6 @@ _data = {"Facility": "SNS",
          "OutputDir": "./output",
          "AlignAndFocusArgs": {},
          }
-
-# _empty_row = {'Activate': True,
-#               'Data': copy.deepcopy(_data)}
 
 
 class TableFileExporter:
@@ -262,12 +260,12 @@ class TableFileExporter:
             self.parent.master_table_list_ui[key][element]['geometry']['radius']['value'].text())
         radius2 = 'N/A'
         height = 'N/A'
-        if shape == 'Cylinder':
+        if shape in ['Cylinder', 'Hollow Cylinder']:
             height = str(
                 self.parent.master_table_list_ui[key][element]['geometry']['height']['value'].text())
         elif shape == 'Sphere':
             pass
-        else:
+        if shape == "Hollow Cylinder":
             radius2 = str(
                 self.parent.master_table_list_ui[key][element]['geometry']['radius2']['value'].text())
 
@@ -308,7 +306,6 @@ class TableFileExporter:
             placzek_infos["lambda_calc_delta"],
             placzek_infos["lambda_calc_max"])
 
-        print("DICT ELEMENT:", dict_element)
         return dict_element
 
     def _get_key_value_dict(self, row=-1):
@@ -498,7 +495,8 @@ class TableFileExporter:
 
         return dictionary
 
-    def _remove_keys_from_with_nan_values(self, dictionary, selected_values=None):
+    def _remove_keys_from_with_nan_values(
+            self, dictionary, selected_values=None):
         """Remove keys in a dictionary if the value is NaN
 
         :param dictionary: Dictionary with keys we want to check
@@ -513,11 +511,14 @@ class TableFileExporter:
         if selected_values is None:
             selected_values = list(dictionary.keys()).copy()
 
-        # Warn if selected_values is not a proper subset of the keys in the dict
+        # Warn if selected_values is not a proper subset of the keys in the
+        # dict
         if not set(selected_values).issubset(dictionary.keys()):
             err_string = "Found keys that are not part dictionary\n"
-            err_string +="  List with 'erroneous' key: {} \n".format(",".join(selected_values))
-            err_string +="  Dictionary keys: {} \n".format(",".join(dictionary.keys()))
+            err_string += "  List with 'erroneous' key: {} \n".format(
+                ",".join(selected_values))
+            err_string += "  Dictionary keys: {} \n".format(
+                ",".join(dictionary.keys()))
             raise Exception(err_string)
 
         # Remove keys with NaN values
@@ -530,11 +531,63 @@ class TableFileExporter:
 
         return dictionary
 
+    def _check_necessary_geometry_keys_exist(self, geometry):
+        """ Check we have necessary keys for the specified geometry shape
+
+        :param geometry: Geometry from ADDIE Table (pre-reduction-ready)
+        "type geometry: dict
+
+        :return: Geometry dictionary that has been checked for necessary keys
+        :rtype: dict
+        """
+        # Grab shape we need to check against
+        shape = geometry['Shape']
+
+        # Find necessary keys from geometry_handler.table2mantid dict
+        shape_dict = table2mantid[shape].copy()
+        necessary_keys = list(shape_dict.keys())
+
+        # Make sure all necessary keys exist
+        for key in necessary_keys:
+            if key not in geometry:
+                err_string = "Did not find key {} in geometry {}".format(
+                    key, geometry)
+                raise Exception(err_string)
+
+    def _map_table_to_mantid_geometry(self, geometry):
+        """ Map from table geometry to mantid geometry using geometry_handler.table2mantid
+
+        :param geometry: Geometry from ADDIE Table (pre-reduction-ready and checked)
+        "type geometry: dict
+
+        :return: Reduction-ready geometry dictionary
+        :rtype: dict
+        """
+        # Grab shape we need to check against
+        shape = geometry['Shape']
+
+        # Get map from geometry_handler.table2mantid dict
+        shape_dict = table2mantid[shape].copy()
+
+        # Construct new geometry dict with mantid keys and do value processing
+        # for the mapping
+        new_geometry = dict()
+        for k, v in geometry.items():
+            new_key = shape_dict[k]["Key"]
+            if "ValueProcessor" in shape_dict[k]:
+                value_processor = shape_dict[k]["ValueProcessor"]
+                new_value = value_processor(v)
+            else:
+                new_value = v
+            new_geometry[new_key] = new_value
+
+        return new_geometry
+
     def geometry_selection_for_reduction(self, dictionary):
-        """Processing of the pre-reduction JSON's `Geometry` to return
+        """Processing of the pre-reduction-ready JSON's `Geometry` to return
         a reduction-ready `Geometry` section in the passed dictionary
 
-        :param dictionary: Pre-reduction JSON with preliminary `Geometry` section
+        :param dictionary: Pre-reduction-ready JSON with preliminary `Geometry` section
         :type row: dict
 
         :return: JSON dictionary with reduction-ready `Geometry` section
@@ -550,31 +603,23 @@ class TableFileExporter:
             return dictionary
 
         # Remove all NaN values from Geometry
-        dictionary['Geometry'] = self._remove_keys_from_with_nan_values(dictionary['Geometry'])
+        dictionary['Geometry'] = self._remove_keys_from_with_nan_values(
+            dictionary['Geometry'])
 
         # return if no shape in Geometry, will use default in Mantid
-        if 'Shape' not in dictionary['Geometry']:    
+        if 'Shape' not in dictionary['Geometry']:
             return dictionary
 
-        # Get shapes
+        # Get geometry and check if we have the necessary geometry keys for the
+        # shape
         geometry = dictionary['Geometry']
+        self._check_necessary_geometry_keys_exist(geometry)
 
-        """
-        if density['UseNumberDensity']:
-            mass_density = self._get_mass_density_from_number_density(
-                dictionary)
-
-        if density['UseMass']:
-            mass_density = self._get_mass_density_from_mass(dictionary)
-
-        # Post-process for output: take out overall Density and add MassDensity
-        # key
-        dictionary.pop('Density')
-        dictionary['MassDensity'] = mass_density
-        """
+        # Construct new geometry dict based on table to mantid mapping
+        geometry = self._map_table_to_mantid_geometry(geometry)
+        dictionary['Geometry'] = geometry
 
         return dictionary
-
 
     def convert_from_row_to_reduction(self, json_input):
         """Processing of the pre-reduction JSON's `Density` to return
@@ -588,13 +633,9 @@ class TableFileExporter:
         """
         reduction_input = json_input
         for element in ["Sample", "Normalization"]:
-            print("\n\n*** ", element, " ***\n\n")
             element_section = reduction_input[element]
-            print("\n\nBefore Reduction row:", reduction_input[element])
-            element_section = self.density_selection_for_reduction(element_section)
+            element_section = self.density_selection_for_reduction(
+                element_section)
             self.geometry_selection_for_reduction(element_section)
-            print("\n\nAfter Reduction row:", reduction_input[element])
-
-        print("\n\n")
 
         return reduction_input

--- a/addie/processing/mantid/master_table/table_row_handler.py
+++ b/addie/processing/mantid/master_table/table_row_handler.py
@@ -851,16 +851,16 @@ class TableRowHandler:
                     'Carpenter',
                     'Mayers',
                     'Podman & Pings',
-                    'Monte-Carlo',
+                    'Monte Carlo',
                     'Numerical',
                     ]
         elif shape == 1: # sphere
             return ['None',
-                    'Monte-Carlo',
+                    'Monte Carlo',
                     ]
         elif shape== 2: # hollow cylinder
             return ['None',
-                    'Monte-Carlo']
+                    'Monte Carlo']
 
         return ['None']
 


### PR DESCRIPTION
This fixes the table -> mantid mapping of the geometry plus some bug fixes and small syntax changes.

Closes #244 

**To test**
I made sure for all three geometries, I see the correct Mantid geometry after pressing `Launch Reduction` in the console after adding either of the following print statements:

 - printing out the row in `element_section` after the `self.geometry_selection_for_reduction(element_section)` method call in 
`addie.processing.mantid.master_table.master_table_exporter.convert_from_row_to_reduction` found [here](https://github.com/neutrons/addie/blob/76e54cdc0472226e1abfac0ee70a60cdde9450b0/addie/processing/mantid/master_table/master_table_exporter.py#L639)

 - more directly, I printed out the geometry portion before and after the `self._map_table_to_mantid_geometry(geometry)` call in `addie.processing.mantid.master_table.master_table_exporter.geometry_selection_for_reduction` found [here](https://github.com/neutrons/addie/blob/76e54cdc0472226e1abfac0ee70a60cdde9450b0/addie/processing/mantid/master_table/master_table_exporter.py#L619)

