### PR TITLE
Fixes for table exporting, pretty print test table, and Inelastic Correction display

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,12 @@ install:
   conda config --set always_yes yes --set changeps1 no --set anaconda_upload no
   conda config --add channels conda-forge --add channels marshallmcdonnell --add channels mantid --add channels mantid/label/nightly
 
-  conda update  -q conda
+  # conda update  -q conda
+  # pinned because 4.7.7 is broken when using `conda update -q conda`
+  # can remove this if this issue is closed:
+  # - https://github.com/conda/conda/issues/8934
+  conda install  -q conda==4.7.5;
+
   conda info -a
 
   # Activate environment

--- a/Pipfile
+++ b/Pipfile
@@ -19,4 +19,4 @@ six = "==1.11.0"
 QtPy = "==1.6.0"
 flake8 = "==3.7.8"
 addie = {editable = true,path = "."}
-simplejson = "3.16.0"
+simplejson = "==3.16.0"

--- a/Pipfile
+++ b/Pipfile
@@ -6,16 +6,17 @@ verify_ssl = true
 [dev-packages]
 
 [packages]
-mantid-total-scattering = "*"
+mantid-total-scattering = "==0.2.8"
 matplotlib = "==2.2.3"
 mock = "==2.0.0"
 numpy = "==1.15.4"
 oauthlib = "==3.0.0"
 pytest = "==4.2.1"
 periodictable = "==1.5.0"
-psutil = "*"
+psutil = "==5.6.3"
 pyoncat = {file = "https://oncat.ornl.gov/packages/pyoncat-1.3.2-py2.py3-none-any.whl"}
 six = "==1.11.0"
 QtPy = "==1.6.0"
-flake8 = "*"
+flake8 = "==3.7.8"
 addie = {editable = true,path = "."}
+simplejson = "3.16.0"

--- a/addie/autoNOM/make_exp_ini_file_and_run_autonom.py
+++ b/addie/autoNOM/make_exp_ini_file_and_run_autonom.py
@@ -170,7 +170,7 @@ class MakeExpIniFileAndRunAutonom(object):
             _mantid_calibration = calstring % (_year, _month)
             _mantid_calibration += calformat % (int(_diamond), _today, _samp_env)
             with open(input_file, 'w') as handle:
-                json.dump(_cal_input, handle)
+                json.dump(_cal_input, handle, indent=2)
         elif not found_in_current_cycle and found_in_previous_cycle:
             _mantid_calibration = current_cal_file
         elif found_in_previous_cycle:

--- a/addie/autoNOM/make_exp_ini_file_and_run_autonom.py
+++ b/addie/autoNOM/make_exp_ini_file_and_run_autonom.py
@@ -1,7 +1,7 @@
 from __future__ import (absolute_import, division, print_function)
 import os
 import time
-import json
+import simplejson
 from datetime import datetime
 import re
 
@@ -170,7 +170,7 @@ class MakeExpIniFileAndRunAutonom(object):
             _mantid_calibration = calstring % (_year, _month)
             _mantid_calibration += calformat % (int(_diamond), _today, _samp_env)
             with open(input_file, 'w') as handle:
-                json.dump(_cal_input, handle, indent=2)
+                simplejson.dump(_cal_input, handle, indent=2, ignore_nan=True)
         elif not found_in_current_cycle and found_in_previous_cycle:
             _mantid_calibration = current_cal_file
         elif found_in_previous_cycle:

--- a/addie/initialization/widgets/configuration.py
+++ b/addie/initialization/widgets/configuration.py
@@ -1,4 +1,4 @@
-import json
+import simplejson
 
 
 class ConfigurationInitializer:
@@ -6,7 +6,7 @@ class ConfigurationInitializer:
     def __init__(self, parent=None):
 
         with open(parent.addie_config_file) as f:
-            data = json.load(f)
+            data = simplejson.load(f)
 
         parent.instrument["full_name"] = data["instrument"]["current"]["full_name"]
         parent.instrument["short_name"] = data["instrument"]["current"]["short_name"]

--- a/addie/processing/mantid/make_calibration_handler/make_calibration.py
+++ b/addie/processing/mantid/make_calibration_handler/make_calibration.py
@@ -10,7 +10,7 @@ import datetime
 from collections import namedtuple
 import numpy as np
 import os
-import json
+import simplejson
 import re
 
 from addie.utilities.gui_handler import TableHandler
@@ -88,7 +88,7 @@ class MakeCalibrationWindow(QMainWindow):
         # list of sample environment
         config_file = self.addie_config_file
         with open(config_file) as f:
-            data = json.load(f)
+            data = simplejson.load(f)
         list_environment = data['sample_environment']
         self.ui.sample_environment_combobox.addItems(list_environment)
 
@@ -403,7 +403,7 @@ class MakeCalibrationWindow(QMainWindow):
                                  filter={'json (*.json)':'json'})
         if _file:
             with open(_file, 'w') as fp:
-                json.dump(o_dict.dictionary, fp, indent=2)
+                simplejson.dump(o_dict.dictionary, fp, indent=2, ignore_nan=True)
 
     def closeEvent(self, c):
         self.parent.make_calibration_ui = None

--- a/addie/processing/mantid/make_calibration_handler/make_calibration.py
+++ b/addie/processing/mantid/make_calibration_handler/make_calibration.py
@@ -403,7 +403,7 @@ class MakeCalibrationWindow(QMainWindow):
                                  filter={'json (*.json)':'json'})
         if _file:
             with open(_file, 'w') as fp:
-                json.dump(o_dict.dictionary, fp)
+                json.dump(o_dict.dictionary, fp, indent=2)
 
     def closeEvent(self, c):
         self.parent.make_calibration_ui = None

--- a/addie/processing/mantid/master_table/import_from_database/gui_handler.py
+++ b/addie/processing/mantid/master_table/import_from_database/gui_handler.py
@@ -149,12 +149,6 @@ class ImportFromDatabaseTableHandler:
 
             self.parent.first_time_filling_table = False
 
-    # def _json_extractor(self, json=None, list_args=[]):
-    #     if len(list_args) == 1:
-    #         return json[list_args[0]]
-    #     else:
-    #         return self._json_extractor(json[list_args.pop(0)],
-    #                                     list_args=list_args)
 
     def _set_table_item(self, json=None, metadata_filter={}, row=-1, col=-1):
         """Populate the filter metadada table from the oncat json file of only the arguments specified in

--- a/addie/processing/mantid/master_table/import_from_database/gui_handler.py
+++ b/addie/processing/mantid/master_table/import_from_database/gui_handler.py
@@ -15,13 +15,16 @@ class FilterTableHandler:
     def __init__(self, table_ui=None):
         self.table_ui = table_ui
 
-    def return_first_row_for_this_item_value(self, string_to_find="", column_to_look_for=-1):
+    def return_first_row_for_this_item_value(
+            self, string_to_find="", column_to_look_for=-1):
         """return the first row found where the item value matches the string passed.
         If the string can not be found, return -1
         """
         nbr_rows = self.table_ui.rowCount()
         for _row in np.arange(nbr_rows):
-            item_value = str(self.table_ui.item(_row, column_to_look_for).text())
+            item_value = str(
+                self.table_ui.item(
+                    _row, column_to_look_for).text())
             if string_to_find == item_value:
                 return _row
         return -1
@@ -54,16 +57,23 @@ class FilterResultTableHandler:
         does, return the column index. If this keyword can not be found, return -1"""
         nbr_columns = self.table_ui.columnCount()
         for _col in np.arange(nbr_columns):
-            column_header = str(self.table_ui.horizontalHeaderItem(_col).text())
+            column_header = str(
+                self.table_ui.horizontalHeaderItem(_col).text())
             if column_header == keyword:
                 return _col
         return -1
 
-    def get_rows_of_matching_string(self, column_to_look_for=-1, string_to_find='', criteria='is'):
+    def get_rows_of_matching_string(
+            self,
+            column_to_look_for=-1,
+            string_to_find='',
+            criteria='is'):
         nbr_row = self.table_ui.rowCount()
         list_matching_rows = []
         for _row in np.arange(nbr_row):
-            string_at_this_row = str(self.table_ui.item(_row, column_to_look_for).text())
+            string_at_this_row = str(
+                self.table_ui.item(
+                    _row, column_to_look_for).text())
             if criteria == 'is':
                 if string_at_this_row == string_to_find:
                     list_matching_rows.append(_row)
@@ -106,15 +116,16 @@ class GuiHandler:
 
         enable_import = False
 
-        if window_ui.toolBox.currentIndex() == 0: # import everything
+        if window_ui.toolBox.currentIndex() == 0:  # import everything
 
             nbr_row = window_ui.tableWidget_all_runs.rowCount()
             if nbr_row > 0:
                 enable_import = True
 
-        else: # rule tab
+        else:  # rule tab
 
-            o_gui = FilterResultTableHandler(table_ui=window_ui.tableWidget_filter_result)
+            o_gui = FilterResultTableHandler(
+                table_ui=window_ui.tableWidget_filter_result)
             nbr_row_visible = o_gui.get_number_of_visible_rows()
             if nbr_row_visible > 0:
                 enable_import = True
@@ -148,7 +159,6 @@ class ImportFromDatabaseTableHandler:
                                      col=_column)
 
             self.parent.first_time_filling_table = False
-
 
     def _set_table_item(self, json=None, metadata_filter={}, row=-1, col=-1):
         """Populate the filter metadada table from the oncat json file of only the arguments specified in
@@ -209,14 +219,15 @@ class ImportFromDatabaseTableHandler:
 
                 path = oncat_template[_col]['path']
                 list_path = path.split(".")
-                argument_value = json_extractor(json=json,
-                                                list_args=copy.deepcopy(list_path))
+                argument_value = json_extractor(
+                    json=json, list_args=copy.deepcopy(list_path))
 
                 # used to evaluate expression returned by ONCat
                 if oncat_template[_col]['formula']:
 
                     # the expression will look like '{value/10e11}'
-                    # so value will be replaced by argument_value and the expression will be evaluated using eval
+                    # so value will be replaced by argument_value and the
+                    # expression will be evaluated using eval
                     value = argument_value  # noqa: F841
                     argument_value = eval(oncat_template[_col]['formula'])
                     argument_value = argument_value.pop()

--- a/addie/processing/mantid/master_table/master_table_exporter.py
+++ b/addie/processing/mantid/master_table/master_table_exporter.py
@@ -297,7 +297,6 @@ class TableFileExporter:
 
 
         if inelastic_correction not in self.__nan_list:
-            print(inelastic_correction, self.__nan_list, placzek_infos)
             dict_element["InelasticCorrection"]["Order"] = placzek_infos["order_text"]
             dict_element["InelasticCorrection"]["Self"] = placzek_infos["is_self"]
             dict_element["InelasticCorrection"]["Interference"] = placzek_infos["is_interference"]
@@ -311,7 +310,6 @@ class TableFileExporter:
                 placzek_infos["lambda_calc_min"],
                 placzek_infos["lambda_calc_delta"],
                 placzek_infos["lambda_calc_max"])
-            print("DICT ELEMENT Placzek:", dict_element["InelasticCorrection"])
         else:
             dict_element.pop("InelasticCorrection")
 

--- a/addie/processing/mantid/master_table/master_table_exporter.py
+++ b/addie/processing/mantid/master_table/master_table_exporter.py
@@ -295,18 +295,27 @@ class TableFileExporter:
 
         placzek_infos = self.parent.master_table_list_ui[key][element]['placzek_infos']
 
-        dict_element["InelasticCorrection"]["Order"] = placzek_infos["order_index"]
-        dict_element["InelasticCorrection"]["Self"] = placzek_infos["is_self"]
-        dict_element["InelasticCorrection"]["Interference"] = placzek_infos["is_interference"]
-        dict_element["InelasticCorrection"]["FitSpectrumWith"] = placzek_infos["fit_spectrum_index"]
-        dict_element["InelasticCorrection"]["LambdaBinningForFit"] = "{},{},{}".format(
-            placzek_infos["lambda_fit_min"],
-            placzek_infos["lambda_fit_delta"],
-            placzek_infos["lambda_fit_max"])
-        dict_element["InelasticCorrection"]["LambdaBinningForCalc"] = "{},{},{}".format(
-            placzek_infos["lambda_calc_min"],
-            placzek_infos["lambda_calc_delta"],
-            placzek_infos["lambda_calc_max"])
+
+        if inelastic_correction not in self.__nan_list:
+            print(inelastic_correction, self.__nan_list, placzek_infos)
+            dict_element["InelasticCorrection"]["Order"] = placzek_infos["order_text"]
+            dict_element["InelasticCorrection"]["Self"] = placzek_infos["is_self"]
+            dict_element["InelasticCorrection"]["Interference"] = placzek_infos["is_interference"]
+            fit_spectrum_text = placzek_infos["fit_spectrum_text"].replace(".", "").replace(" ", "")
+            dict_element["InelasticCorrection"]["FitSpectrumWith"] = fit_spectrum_text
+            dict_element["InelasticCorrection"]["LambdaBinningForFit"] = "{},{},{}".format(
+                placzek_infos["lambda_fit_min"],
+                placzek_infos["lambda_fit_delta"],
+                placzek_infos["lambda_fit_max"])
+            dict_element["InelasticCorrection"]["LambdaBinningForCalc"] = "{},{},{}".format(
+                placzek_infos["lambda_calc_min"],
+                placzek_infos["lambda_calc_delta"],
+                placzek_infos["lambda_calc_max"])
+            print("DICT ELEMENT Placzek:", dict_element["InelasticCorrection"])
+        else:
+            dict_element.pop("InelasticCorrection")
+
+
 
         return dict_element
 

--- a/addie/processing/mantid/master_table/master_table_exporter.py
+++ b/addie/processing/mantid/master_table/master_table_exporter.py
@@ -251,7 +251,8 @@ class TableFileExporter:
         column += 1
         packing_fraction = self._get_item_value(row=row, column=column)
         if packing_fraction and packing_fraction not in self.__nan_list:
-            dict_element["PackingFraction"] = float(packing_fraction.strip("\""))
+            dict_element["PackingFraction"] = float(
+                packing_fraction.strip("\""))
 
         column += 1
         shape = self._get_selected_value(row=row, column=column)
@@ -295,12 +296,15 @@ class TableFileExporter:
 
         placzek_infos = self.parent.master_table_list_ui[key][element]['placzek_infos']
 
-
         if inelastic_correction not in self.__nan_list:
             dict_element["InelasticCorrection"]["Order"] = placzek_infos["order_text"]
             dict_element["InelasticCorrection"]["Self"] = placzek_infos["is_self"]
             dict_element["InelasticCorrection"]["Interference"] = placzek_infos["is_interference"]
-            fit_spectrum_text = placzek_infos["fit_spectrum_text"].replace(".", "").replace(" ", "")
+            fit_spectrum_text = placzek_infos["fit_spectrum_text"].replace(
+                ".",
+                "").replace(
+                " ",
+                "")
             dict_element["InelasticCorrection"]["FitSpectrumWith"] = fit_spectrum_text
             dict_element["InelasticCorrection"]["LambdaBinningForFit"] = "{},{},{}".format(
                 placzek_infos["lambda_fit_min"],
@@ -312,8 +316,6 @@ class TableFileExporter:
                 placzek_infos["lambda_calc_max"])
         else:
             dict_element.pop("InelasticCorrection")
-
-
 
         return dict_element
 

--- a/addie/processing/mantid/master_table/master_table_exporter.py
+++ b/addie/processing/mantid/master_table/master_table_exporter.py
@@ -109,7 +109,7 @@ class TableFileExporter:
 
         # write out the configuration
         with open(filename, 'w') as outfile:
-            json.dump(dictionary, outfile)
+            json.dump(dictionary, outfile, indent=2)
 
     def isActive(self, row):
         """Determine if `row` is activated for reduction

--- a/addie/processing/mantid/master_table/master_table_exporter.py
+++ b/addie/processing/mantid/master_table/master_table_exporter.py
@@ -1,7 +1,7 @@
 from __future__ import (absolute_import, division, print_function)
 from collections import OrderedDict
 import copy
-import json
+import simplejson
 import numpy as np
 import os
 
@@ -73,6 +73,7 @@ class TableFileExporter:
     def __init__(self, parent=None):
         self.parent = parent
         self.table_ui = parent.processing_ui.h3_table
+        self.__nan_list = ['N/A', 'None']
 
         # generic elements to take from the ui
         self.facility = self.parent.facility
@@ -109,7 +110,7 @@ class TableFileExporter:
 
         # write out the configuration
         with open(filename, 'w') as outfile:
-            json.dump(dictionary, outfile, indent=2)
+            simplejson.dump(dictionary, outfile, indent=2, ignore_nan=True)
 
     def isActive(self, row):
         """Determine if `row` is activated for reduction
@@ -249,7 +250,7 @@ class TableFileExporter:
 
         column += 1
         packing_fraction = self._get_item_value(row=row, column=column)
-        if packing_fraction:
+        if packing_fraction and packing_fraction not in self.__nan_list:
             dict_element["PackingFraction"] = float(packing_fraction.strip("\""))
 
         column += 1
@@ -271,11 +272,11 @@ class TableFileExporter:
                 self.parent.master_table_list_ui[key][element]['geometry']['radius2']['value'].text())
 
         dict_element["Geometry"]["Radius"] = np.NaN if (
-            radius == 'N/A') else float(radius)
+            radius in self.__nan_list) else float(radius)
         dict_element["Geometry"]["Radius2"] = np.NaN if (
-            radius2 == 'N/A') else float(radius2)
+            radius2 in self.__nan_list) else float(radius2)
         dict_element["Geometry"]["Height"] = np.NaN if (
-            height == 'N/A') else float(height)
+            height in self.__nan_list) else float(height)
 
         column += 1
         abs_correction = self._get_selected_value(row=row, column=column)

--- a/addie/processing/mantid/master_table/master_table_loader.py
+++ b/addie/processing/mantid/master_table/master_table_loader.py
@@ -3,7 +3,7 @@ import os
 import numpy as np
 from collections import OrderedDict
 import copy
-import json
+import simplejson
 
 from qtpy.QtWidgets import QDialog
 from addie.utilities import load_ui
@@ -218,7 +218,7 @@ class JsonLoader:
 
         # load json
         with open(self.filename) as f:
-            data = json.load(f)
+            data = simplejson.load(f)
 
         # convert into UI dictionary
         list_keys = sorted([_key for _key in data.keys()])
@@ -693,8 +693,7 @@ class FromDictionaryToTableUi:
         # packing_fraction
         column += 1
         self.table_ui.item(
-            row, column).setText(
-            entry[data_type]["packing_fraction"])
+            row, column).setText(str(entry[data_type]["packing_fraction"]))
 
         # geometry - shape
         column += 1

--- a/addie/processing/mantid/master_table/reduction_configuration_handler.py
+++ b/addie/processing/mantid/master_table/reduction_configuration_handler.py
@@ -1,5 +1,5 @@
 from __future__ import (absolute_import, division, print_function)
-import json
+import simplejson
 from qtpy.QtWidgets import QDialog, QFileDialog, QTableWidgetItem
 from addie.utilities import load_ui
 from qtpy import QtGui, QtCore
@@ -366,7 +366,7 @@ class LoadReductionConfiguration:
         if grand_parent.reduction_configuration == {}:
             config_file = grand_parent.addie_config_file
             with open(config_file) as f:
-                data = json.load(f)
+                data = simplejson.load(f)
             pdf_q_range = data['pdf']['q_range']
             pdf_r_range = data['pdf']['r_range']
             pdf_reduction_configuration_file = data["pdf"]["reduction_configuration_file"]

--- a/addie/processing/mantid/master_table/table_row_handler.py
+++ b/addie/processing/mantid/master_table/table_row_handler.py
@@ -122,7 +122,9 @@ class TableRowHandler:
         if value == 0:
             show_button = False
 
-        _ui = self.main_window.master_table_list_ui[key][data_type]['placzek_button']
+        info = self.main_window.master_table_list_ui[key][data_type]
+
+        _ui = info['placzek_button']
         _ui.setVisible(show_button)
 
         # change state of other widgets of the same column if they are selected
@@ -131,6 +133,10 @@ class TableRowHandler:
         column = self.get_column(data_type=data_type,
                                  sample_norm_column=INDEX_OF_INELASTIC_CORRECTION)
         self.main_window.check_master_table_column_highlighting(column=column)
+
+        inelastic_correction = info['inelastic_correction'].currentText()
+        if inelastic_correction not in ["None", None]:
+            PlaczekHandler(parent=self.main_window, key=key, data_type=data_type)
 
     def multi_scattering_correction(self, value='', key=None, data_type='sample'):
         # change state of other widgets of the same column if they are selected

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - psutil
     - python
     - setuptools
+    - simplejson
 
   run:
     - configparser
@@ -28,6 +29,7 @@ requirements:
     - periodictable
     - psutil
     - python
+    - simplejson
 
 test:
   imports:

--- a/install-requirements.txt
+++ b/install-requirements.txt
@@ -2,3 +2,4 @@ mantid-total-scattering
 periodictable
 psutil
 QtPy
+simplejson

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,3 @@
 mock
 pytest
+simplejson

--- a/tests/nano3_test_table.json
+++ b/tests/nano3_test_table.json
@@ -1,1 +1,409 @@
-{"000": {"Activate": false, "Title": "MT_furnace", "Sample": {"Runs": "92627", "Background": {"Runs": "", "Background": {"Runs": ""}}, "Material": "N/A", "Density": {"MassDensity": "N/A", "UseMassDensity": true, "NumberDensity": "N/A", "UseNumberDensity": false, "Mass": "N/A", "UseMass": false}, "PackingFraction": "1", "Geometry": {"Shape": "Cylinder", "Radius": NaN, "Radius2": NaN, "Height": NaN}, "AbsorptionCorrection": {"Type": "None"}, "MultipleScatteringCorrection": {"Type": "None"}, "InelasticCorrection": {"Type": "None", "Order": 0, "Self": true, "Interference": false, "FitSpectrumWith": 0, "LambdaBinningForFit": "0.16,0.04,2.8", "LambdaBinningForCalc": "0.1,0.0001,3.0"}}, "Normalization": {"Runs": "", "Background": {"Runs": "", "Background": {"Runs": ""}}, "Material": "N/A", "Density": {"MassDensity": "N/A", "UseMassDensity": true, "NumberDensity": "N/A", "UseNumberDensity": false, "Mass": "N/A", "UseMass": false}, "PackingFraction": "", "Geometry": {"Shape": "Cylinder", "Radius": NaN, "Radius2": NaN, "Height": NaN}, "AbsorptionCorrection": {"Type": "None"}, "MultipleScatteringCorrection": {"Type": "None"}, "InelasticCorrection": {"Type": "None", "Order": 0, "Self": true, "Interference": false, "FitSpectrumWith": 0, "LambdaBinningForFit": "0.16,0.04,2.8", "LambdaBinningForCalc": "0.1,0.0001,3.0"}}, "Calibration": {"Filename": "/SNS/NOM/shared/CALIBRATION/2017_1_1B_CAL/NOM_d92639_2017_04_24_furnace.h5"}, "Facility": "SNS", "Instrument": "NOM", "CacheDir": "./tmp", "OutputDir": "./output", "Merging": {"QBinning": [], "SumBanks": [], "Characterizations": "", "Grouping": {"Initial": "", "Output": ""}}, "AlignAndFocusArgs": {}}, "001": {"Activate": false, "Title": "MT_6mm_can_furnace_27C_setpoint", "Sample": {"Runs": "92628", "Background": {"Runs": "", "Background": {"Runs": ""}}, "Material": "N/A", "Density": {"MassDensity": "N/A", "UseMassDensity": true, "NumberDensity": "N/A", "UseNumberDensity": false, "Mass": "N/A", "UseMass": false}, "PackingFraction": "1", "Geometry": {"Shape": "Cylinder", "Radius": NaN, "Radius2": NaN, "Height": NaN}, "AbsorptionCorrection": {"Type": "None"}, "MultipleScatteringCorrection": {"Type": "None"}, "InelasticCorrection": {"Type": "None", "Order": 0, "Self": true, "Interference": false, "FitSpectrumWith": 0, "LambdaBinningForFit": "0.16,0.04,2.8", "LambdaBinningForCalc": "0.1,0.0001,3.0"}}, "Normalization": {"Runs": "", "Background": {"Runs": "", "Background": {"Runs": ""}}, "Material": "N/A", "Density": {"MassDensity": "N/A", "UseMassDensity": true, "NumberDensity": "N/A", "UseNumberDensity": false, "Mass": "N/A", "UseMass": false}, "PackingFraction": "", "Geometry": {"Shape": "Cylinder", "Radius": NaN, "Radius2": NaN, "Height": NaN}, "AbsorptionCorrection": {"Type": "None"}, "MultipleScatteringCorrection": {"Type": "None"}, "InelasticCorrection": {"Type": "None", "Order": 0, "Self": true, "Interference": false, "FitSpectrumWith": 0, "LambdaBinningForFit": "0.16,0.04,2.8", "LambdaBinningForCalc": "0.1,0.0001,3.0"}}, "Calibration": {"Filename": "/SNS/NOM/shared/CALIBRATION/2017_1_1B_CAL/NOM_d92639_2017_04_24_furnace.h5"}, "Facility": "SNS", "Instrument": "NOM", "CacheDir": "./tmp", "OutputDir": "./output", "Merging": {"QBinning": [], "SumBanks": [], "Characterizations": "", "Grouping": {"Initial": "", "Output": ""}}, "AlignAndFocusArgs": {}}, "002": {"Activate": false, "Title": "MT_6mm_PAC", "Sample": {"Runs": "92629-92634", "Background": {"Runs": "", "Background": {"Runs": ""}}, "Material": "N/A", "Density": {"MassDensity": "N/A", "UseMassDensity": true, "NumberDensity": "N/A", "UseNumberDensity": false, "Mass": "N/A", "UseMass": false}, "PackingFraction": "1", "Geometry": {"Shape": "Cylinder", "Radius": NaN, "Radius2": NaN, "Height": NaN}, "AbsorptionCorrection": {"Type": "None"}, "MultipleScatteringCorrection": {"Type": "None"}, "InelasticCorrection": {"Type": "None", "Order": 0, "Self": true, "Interference": false, "FitSpectrumWith": 0, "LambdaBinningForFit": "0.16,0.04,2.8", "LambdaBinningForCalc": "0.1,0.0001,3.0"}}, "Normalization": {"Runs": "", "Background": {"Runs": "", "Background": {"Runs": ""}}, "Material": "N/A", "Density": {"MassDensity": "N/A", "UseMassDensity": true, "NumberDensity": "N/A", "UseNumberDensity": false, "Mass": "N/A", "UseMass": false}, "PackingFraction": "", "Geometry": {"Shape": "Cylinder", "Radius": NaN, "Radius2": NaN, "Height": NaN}, "AbsorptionCorrection": {"Type": "None"}, "MultipleScatteringCorrection": {"Type": "None"}, "InelasticCorrection": {"Type": "None", "Order": 0, "Self": true, "Interference": false, "FitSpectrumWith": 0, "LambdaBinningForFit": "0.16,0.04,2.8", "LambdaBinningForCalc": "0.1,0.0001,3.0"}}, "Calibration": {"Filename": "/SNS/NOM/shared/CALIBRATION/2017_1_1B_CAL/NOM_d92639_2017_04_24_furnace.h5"}, "Facility": "SNS", "Instrument": "NOM", "CacheDir": "./tmp", "OutputDir": "./output", "Merging": {"QBinning": [], "SumBanks": [], "Characterizations": "", "Grouping": {"Initial": "", "Output": ""}}, "AlignAndFocusArgs": {}}, "003": {"Activate": true, "Title": "NaNO3_150C", "Sample": {"Runs": "92651,92720,92721", "Background": {"Runs": "92629-92634", "Background": {"Runs": "92627"}}, "Material": "Na N O3.0", "Density": {"MassDensity": "1.0", "UseMassDensity": true, "NumberDensity": "N/A", "UseNumberDensity": false, "Mass": "N/A", "UseMass": false}, "PackingFraction": "1", "Geometry": {"Shape": "Cylinder", "Radius": 0.3, "Radius2": NaN, "Height": 1.8}, "AbsorptionCorrection": {"Type": "None"}, "MultipleScatteringCorrection": {"Type": "None"}, "InelasticCorrection": {"Type": "None", "Order": 0, "Self": true, "Interference": false, "FitSpectrumWith": 0, "LambdaBinningForFit": "0.16,0.04,2.8", "LambdaBinningForCalc": "0.1,0.0001,3.0"}}, "Normalization": {"Runs": "92636-92637", "Background": {"Runs": "92627", "Background": {"Runs": ""}}, "Material": "V", "Density": {"MassDensity": "6.11", "UseMassDensity": true, "NumberDensity": 0.035427, "UseNumberDensity": false, "Mass": "N/A", "UseMass": false}, "PackingFraction": "1.0", "Geometry": {"Shape": "Cylinder", "Radius": 0.2925, "Radius2": NaN, "Height": 1.8}, "AbsorptionCorrection": {"Type": "Carpenter"}, "MultipleScatteringCorrection": {"Type": "None"}, "InelasticCorrection": {"Type": "Placzek", "Order": 0, "Self": true, "Interference": false, "FitSpectrumWith": 0, "LambdaBinningForFit": "0.16,0.04,2.8", "LambdaBinningForCalc": "0.1,0.0001,3.0"}}, "Calibration": {"Filename": "/SNS/NOM/shared/CALIBRATION/2017_1_1B_CAL/NOM_d92639_2017_04_24_furnace.h5"}, "Facility": "SNS", "Instrument": "NOM", "CacheDir": "./tmp", "OutputDir": "./output", "Merging": {"QBinning": [], "SumBanks": [], "Characterizations": "", "Grouping": {"Initial": "", "Output": ""}}, "AlignAndFocusArgs": {"TMin": "300.0", "TMax": "16667.0"}}}
+{
+  "000": {
+    "Activate": false,
+    "Title": "MT_furnace",
+    "Sample": {
+      "Runs": "92627",
+      "Background": {
+        "Runs": "",
+        "Background": {
+          "Runs": ""
+        }
+      },
+      "Material": "N/A",
+      "Density": {
+        "MassDensity": "N/A",
+        "UseMassDensity": true,
+        "NumberDensity": "N/A",
+        "UseNumberDensity": false,
+        "Mass": "N/A",
+        "UseMass": false
+      },
+      "PackingFraction": 1.0,
+      "Geometry": {
+        "Shape": "Cylinder",
+        "Radius": null,
+        "Radius2": null,
+        "Height": null
+      },
+      "AbsorptionCorrection": {
+        "Type": "None"
+      },
+      "MultipleScatteringCorrection": {
+        "Type": "None"
+      },
+      "InelasticCorrection": {
+        "Type": "None",
+        "Order": 0,
+        "Self": true,
+        "Interference": false,
+        "FitSpectrumWith": 0,
+        "LambdaBinningForFit": "0.16,0.04,2.8",
+        "LambdaBinningForCalc": "0.1,0.0001,3.0"
+      }
+    },
+    "Normalization": {
+      "Runs": "",
+      "Background": {
+        "Runs": "",
+        "Background": {
+          "Runs": ""
+        }
+      },
+      "Material": "N/A",
+      "Density": {
+        "MassDensity": "N/A",
+        "UseMassDensity": true,
+        "NumberDensity": "N/A",
+        "UseNumberDensity": false,
+        "Mass": "N/A",
+        "UseMass": false
+      },
+      "PackingFraction": null,
+      "Geometry": {
+        "Shape": "Cylinder",
+        "Radius": null,
+        "Radius2": null,
+        "Height": null
+      },
+      "AbsorptionCorrection": {
+        "Type": "None"
+      },
+      "MultipleScatteringCorrection": {
+        "Type": "None"
+      },
+      "InelasticCorrection": {
+        "Type": "None",
+        "Order": 0,
+        "Self": true,
+        "Interference": false,
+        "FitSpectrumWith": 0,
+        "LambdaBinningForFit": "0.16,0.04,2.8",
+        "LambdaBinningForCalc": "0.1,0.0001,3.0"
+      }
+    },
+    "Calibration": {
+      "Filename": "/SNS/NOM/shared/CALIBRATION/2017_1_1B_CAL/NOM_d92639_2017_04_24_furnace.h5"
+    },
+    "Facility": "SNS",
+    "Instrument": "NOM",
+    "CacheDir": "./tmp",
+    "OutputDir": "./output",
+    "Merging": {
+      "QBinning": [],
+      "SumBanks": [],
+      "Characterizations": "",
+      "Grouping": {
+        "Initial": "",
+        "Output": ""
+      }
+    },
+    "AlignAndFocusArgs": {}
+  },
+  "001": {
+    "Activate": false,
+    "Title": "MT_6mm_can_furnace_27C_setpoint",
+    "Sample": {
+      "Runs": "92628",
+      "Background": {
+        "Runs": "",
+        "Background": {
+          "Runs": ""
+        }
+      },
+      "Material": "N/A",
+      "Density": {
+        "MassDensity": "N/A",
+        "UseMassDensity": true,
+        "NumberDensity": "N/A",
+        "UseNumberDensity": false,
+        "Mass": "N/A",
+        "UseMass": false
+      },
+      "PackingFraction": 1.0,
+      "Geometry": {
+        "Shape": "Cylinder",
+        "Radius": null,
+        "Radius2": null,
+        "Height": null
+      },
+      "AbsorptionCorrection": {
+        "Type": "None"
+      },
+      "MultipleScatteringCorrection": {
+        "Type": "None"
+      },
+      "InelasticCorrection": {
+        "Type": "None",
+        "Order": 0,
+        "Self": true,
+        "Interference": false,
+        "FitSpectrumWith": 0,
+        "LambdaBinningForFit": "0.16,0.04,2.8",
+        "LambdaBinningForCalc": "0.1,0.0001,3.0"
+      }
+    },
+    "Normalization": {
+      "Runs": "",
+      "Background": {
+        "Runs": "",
+        "Background": {
+          "Runs": ""
+        }
+      },
+      "Material": "N/A",
+      "Density": {
+        "MassDensity": "N/A",
+        "UseMassDensity": true,
+        "NumberDensity": "N/A",
+        "UseNumberDensity": false,
+        "Mass": "N/A",
+        "UseMass": false
+      },
+      "PackingFraction": null,
+      "Geometry": {
+        "Shape": "Cylinder",
+        "Radius": null,
+        "Radius2": null,
+        "Height": null
+      },
+      "AbsorptionCorrection": {
+        "Type": "None"
+      },
+      "MultipleScatteringCorrection": {
+        "Type": "None"
+      },
+      "InelasticCorrection": {
+        "Type": "None",
+        "Order": 0,
+        "Self": true,
+        "Interference": false,
+        "FitSpectrumWith": 0,
+        "LambdaBinningForFit": "0.16,0.04,2.8",
+        "LambdaBinningForCalc": "0.1,0.0001,3.0"
+      }
+    },
+    "Calibration": {
+      "Filename": "/SNS/NOM/shared/CALIBRATION/2017_1_1B_CAL/NOM_d92639_2017_04_24_furnace.h5"
+    },
+    "Facility": "SNS",
+    "Instrument": "NOM",
+    "CacheDir": "./tmp",
+    "OutputDir": "./output",
+    "Merging": {
+      "QBinning": [],
+      "SumBanks": [],
+      "Characterizations": "",
+      "Grouping": {
+        "Initial": "",
+        "Output": ""
+      }
+    },
+    "AlignAndFocusArgs": {}
+  },
+  "002": {
+    "Activate": false,
+    "Title": "MT_6mm_PAC",
+    "Sample": {
+      "Runs": "92629-92634",
+      "Background": {
+        "Runs": "",
+        "Background": {
+          "Runs": ""
+        }
+      },
+      "Material": "N/A",
+      "Density": {
+        "MassDensity": "N/A",
+        "UseMassDensity": true,
+        "NumberDensity": "N/A",
+        "UseNumberDensity": false,
+        "Mass": "N/A",
+        "UseMass": false
+      },
+      "PackingFraction": 1.0,
+      "Geometry": {
+        "Shape": "Cylinder",
+        "Radius": null,
+        "Radius2": null,
+        "Height": null
+      },
+      "AbsorptionCorrection": {
+        "Type": "None"
+      },
+      "MultipleScatteringCorrection": {
+        "Type": "None"
+      },
+      "InelasticCorrection": {
+        "Type": "None",
+        "Order": 0,
+        "Self": true,
+        "Interference": false,
+        "FitSpectrumWith": 0,
+        "LambdaBinningForFit": "0.16,0.04,2.8",
+        "LambdaBinningForCalc": "0.1,0.0001,3.0"
+      }
+    },
+    "Normalization": {
+      "Runs": "",
+      "Background": {
+        "Runs": "",
+        "Background": {
+          "Runs": ""
+        }
+      },
+      "Material": "N/A",
+      "Density": {
+        "MassDensity": "N/A",
+        "UseMassDensity": true,
+        "NumberDensity": "N/A",
+        "UseNumberDensity": false,
+        "Mass": "N/A",
+        "UseMass": false
+      },
+      "PackingFraction": null,
+      "Geometry": {
+        "Shape": "Cylinder",
+        "Radius": null,
+        "Radius2": null,
+        "Height": null
+      },
+      "AbsorptionCorrection": {
+        "Type": "None"
+      },
+      "MultipleScatteringCorrection": {
+        "Type": "None"
+      },
+      "InelasticCorrection": {
+        "Type": "None",
+        "Order": 0,
+        "Self": true,
+        "Interference": false,
+        "FitSpectrumWith": 0,
+        "LambdaBinningForFit": "0.16,0.04,2.8",
+        "LambdaBinningForCalc": "0.1,0.0001,3.0"
+      }
+    },
+    "Calibration": {
+      "Filename": "/SNS/NOM/shared/CALIBRATION/2017_1_1B_CAL/NOM_d92639_2017_04_24_furnace.h5"
+    },
+    "Facility": "SNS",
+    "Instrument": "NOM",
+    "CacheDir": "./tmp",
+    "OutputDir": "./output",
+    "Merging": {
+      "QBinning": [],
+      "SumBanks": [],
+      "Characterizations": "",
+      "Grouping": {
+        "Initial": "",
+        "Output": ""
+      }
+    },
+    "AlignAndFocusArgs": {}
+  },
+  "003": {
+    "Activate": true,
+    "Title": "NaNO3_150C",
+    "Sample": {
+      "Runs": "92651",
+      "Background": {
+        "Runs": "92629",
+        "Background": {
+          "Runs": "92627"
+        }
+      },
+      "Material": "Na N O3.0",
+      "Density": {
+        "MassDensity": "1.0",
+        "UseMassDensity": true,
+        "NumberDensity": "N/A",
+        "UseNumberDensity": false,
+        "Mass": "N/A",
+        "UseMass": false
+      },
+      "PackingFraction": 1.0,
+      "Geometry": {
+        "Shape": "Cylinder",
+        "Radius": 0.3,
+        "Radius2": null,
+        "Height": 1.8
+      },
+      "AbsorptionCorrection": {
+        "Type": "None"
+      },
+      "MultipleScatteringCorrection": {
+        "Type": "None"
+      },
+      "InelasticCorrection": {
+        "Type": "None",
+        "Order": 0,
+        "Self": true,
+        "Interference": false,
+        "FitSpectrumWith": 0,
+        "LambdaBinningForFit": "0.16,0.04,2.8",
+        "LambdaBinningForCalc": "0.1,0.0001,3.0"
+      }
+    },
+    "Normalization": {
+      "Runs": "92636",
+      "Background": {
+        "Runs": "92627",
+        "Background": {
+          "Runs": ""
+        }
+      },
+      "Material": "V",
+      "Density": {
+        "MassDensity": "6.11",
+        "UseMassDensity": true,
+        "NumberDensity": "N/A",
+        "UseNumberDensity": false,
+        "Mass": "N/A",
+        "UseMass": false
+      },
+      "PackingFraction": 1.0,
+      "Geometry": {
+        "Shape": "Cylinder",
+        "Radius": 0.2925,
+        "Radius2": null,
+        "Height": 1.8
+      },
+      "AbsorptionCorrection": {
+        "Type": "Carpenter"
+      },
+      "MultipleScatteringCorrection": {
+        "Type": "None"
+      },
+      "InelasticCorrection": {
+        "Type": "None",
+        "Order": 0,
+        "Self": true,
+        "Interference": false,
+        "FitSpectrumWith": 0,
+        "LambdaBinningForFit": "0.16,0.04,2.8",
+        "LambdaBinningForCalc": "0.1,0.0001,3.0"
+      }
+    },
+    "Calibration": {
+      "Filename": "/SNS/NOM/shared/CALIBRATION/2017_1_1B_CAL/NOM_d92639_2017_04_24_furnace.h5"
+    },
+    "Facility": "SNS",
+    "Instrument": "NOM",
+    "CacheDir": "./tmp",
+    "OutputDir": "./output",
+    "Merging": {
+      "QBinning": [],
+      "SumBanks": [],
+      "Characterizations": "",
+      "Grouping": {
+        "Initial": "",
+        "Output": ""
+      }
+    },
+    "AlignAndFocusArgs": {
+      "TMin": "300.0",
+      "TMax": "16667.0"
+    }
+  }
+}


### PR DESCRIPTION
Fixes #253 and Fixes #249 

**To Test**:
1) Load the `tests/nano3_test_table.json`
2) Export table
3) Re-load the table

Also, check the new format of the test table.

*NOTE*: this adds `simplejson` as a dependency. The `simplejson` package replaces `json` for addie package. However, `json` is still a dependency for `versioneer`, so keeping both.