### PR TITLE
Pins conda==4.7.5 since 4.7.7 is broken

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,12 @@ install:
   conda config --set always_yes yes --set changeps1 no --set anaconda_upload no
   conda config --add channels conda-forge --add channels marshallmcdonnell --add channels mantid --add channels mantid/label/nightly
 
-  conda update  -q conda
+  # conda update  -q conda
+  # pinned because 4.7.7 is broken when using `conda update -q conda`
+  # can remove this if this issue is closed:
+  # - https://github.com/conda/conda/issues/8934
+  conda install  -q conda==4.7.5;
+
   conda info -a
 
   # Activate environment


### PR DESCRIPTION
The issue is reported here. PR is in at time of this writing. Once this is fixed, should unpin this version of conda:

https://github.com/conda/conda/issues/8934