### PR TITLE
Fix row and col args passed to addie.main.check_step2_gui

### DIFF
--- a/addie/main.py
+++ b/addie/main.py
@@ -565,7 +565,7 @@ class MainWindow(QMainWindow):
         postprocessing_event_handler.clear_name_search_clicked(self)
 
     def check_step2_gui(self, row, column):
-        postprocessing_event_handler.check_step2_gui(self)
+        postprocessing_event_handler.check_step2_gui(self, row, column)
 
     # PDF
 


### PR DESCRIPTION
Fixes #270 

Was missing the row and column args to check_step2_gui in addie.main