### PR TITLE
Remove Python 2 support + fixes for CI dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ install:
   - mamba info -a
 
     # BUILD: Create addie build environment
-  - mamba create -q -n addie_build python=$CONDA jupyter_client=5.3.4 conda-build=3.17 conda-verify
+  - mamba create -q -n addie_build python=$CONDA jupyter_client=5.3.4 conda-build conda-verify
   - conda activate addie_build
   - mamba build conda.recipe
   - export PKG_FILE=$(mamba build conda.recipe --output)
@@ -48,7 +48,7 @@ install:
 
 script:
     # TEST: Create test environment and test build
-  - mamba create -q -n addie_test python=$CONDA flake8 jupyter_client=5.3.4 conda-build=3.17 qt=5.6.2 anaconda-client pytest pytest-qt pytest-mpl
+  - mamba create -q -n addie_test python=$CONDA flake8 jupyter_client=5.3.4 conda-build qt=5.6.2 anaconda-client pytest pytest-qt pytest-mpl
   - mamba info --envs
   - conda activate addie_test
   - mkdir -p ${CONDA_PREFIX}/conda-bld/linux-64/

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ cache:
 matrix:
   include:
   - os: linux
-    env: CONDA=2.7
-  - os: linux
     env: CONDA=3.6.7
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ install:
 
 script:
     # TEST: Create test environment and test build
-  - mamba create -q -n addie_test python=$CONDA flake8 jupyter_client=5.3.4 conda-build=3.17 qt=5.6.2 pluggy=0.12 anaconda-client pytest pytest-qt pytest-mpl
+  - mamba create -q -n addie_test python=$CONDA flake8 jupyter_client=5.3.4 conda-build=3.17 qt=5.6.2 anaconda-client pytest pytest-qt pytest-mpl
   - mamba info --envs
   - conda activate addie_test
   - mkdir -p ${CONDA_PREFIX}/conda-bld/linux-64/

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ install:
 
 script:
     # TEST: Create test environment and test build
-  - mamba create -q -n addie_test python=$CONDA flake8 jupyter_client=5.3.4 conda-build=3.17 pluggy=0.12 anaconda-client pytest pytest-qt pytest-mpl
+  - mamba create -q -n addie_test python=$CONDA flake8 jupyter_client=5.3.4 conda-build=3.17 qt=5.6.2 pluggy=0.12 anaconda-client pytest pytest-qt pytest-mpl
   - mamba info --envs
   - conda activate addie_test
   - mkdir -p ${CONDA_PREFIX}/conda-bld/linux-64/

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ install:
   - mamba info -a
 
     # BUILD: Create addie build environment
-  - mamba create -q -n addie_build python=$CONDA jupyter_client=5.3.4 conda-build conda-verify
+  - mamba create -q -n addie_build python=$CONDA conda-build conda-verify
   - conda activate addie_build
   - mamba build conda.recipe
   - export PKG_FILE=$(mamba build conda.recipe --output)
@@ -48,7 +48,7 @@ install:
 
 script:
     # TEST: Create test environment and test build
-  - mamba create -q -n addie_test python=$CONDA flake8 jupyter_client=5.3.4 conda-build qt=5.6.2 anaconda-client pytest pytest-qt pytest-mpl
+  - mamba create -q -n addie_test python=$CONDA qt=5.6.2 flake8 conda-build anaconda-client pytest pytest-qt pytest-mpl
   - mamba info --envs
   - conda activate addie_test
   - mkdir -p ${CONDA_PREFIX}/conda-bld/linux-64/

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
   - os: linux
     env: CONDA=2.7
   - os: linux
-    env: CONDA=3.6
+    env: CONDA=3.6.7
 
 before_install:
 - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ install:
 
 script:
     # TEST: Create test environment and test build
-  - mamba create -q -n addie_test python=$CONDA flake8 jupyter_client=5.3.4 conda-build=3.17 anaconda-client pytest pytest-qt pytest-mpl
+  - mamba create -q -n addie_test python=$CONDA flake8 jupyter_client=5.3.4 conda-build=3.17 pluggy=0.12 anaconda-client pytest pytest-qt pytest-mpl
   - mamba info --envs
   - conda activate addie_test
   - mkdir -p ${CONDA_PREFIX}/conda-bld/linux-64/


### PR DESCRIPTION
Work includes:
 - Removing Python 2 for support (mainly in CI for packaging)
 - Removes old fix for conda-build and jupyter-client in CI
 - Add fix for Qt in pytest-qt testing by pinning version