### PR TITLE
Feature improvement

### DIFF
--- a/addie/addiedriver.py
+++ b/addie/addiedriver.py
@@ -431,10 +431,14 @@ class AddieDriver(object):
                 InputWorkspace=sq_ws_name,
                 OutputWorkspace=sq_ws_name)  # TODO REMOVE THIS LINE
         elif ext == 'DAT' or ext == 'txt':
-            simpleapi.LoadAscii(
-                Filename=file_name,
-                OutputWorkspace=sq_ws_name,
-                Unit='MomentumTransfer')
+            try:
+                simpleapi.LoadAscii(
+                    Filename=file_name,
+                    OutputWorkspace=sq_ws_name,
+                    Unit='MomentumTransfer')
+            except RuntimeError:
+                sq_ws_name, q_min, q_max = "InvalidInput", 0, 0
+                return sq_ws_name, q_min, q_max
             # The S(Q) file is in fact S(Q)-1 in sq file.  So need to add 1 to
             # the workspace
             out_ws = AnalysisDataService.retrieve(sq_ws_name)

--- a/addie/calculate_gr/event_handler.py
+++ b/addie/calculate_gr/event_handler.py
@@ -84,6 +84,8 @@ def load_sq(main_window):
         sq_file_name = str(sq_file_name)
         sq_ws_name, q_min, q_max = main_window._myController.load_sq(
             sq_file_name)
+        if sq_ws_name == "InvalidInput" and q_min == 0 and q_max == 0:
+            return
         # add to color management
         color = main_window._pdfColorManager.add_sofq(sq_ws_name)
 


### PR DESCRIPTION
When the selected S(Q) file is, by mistake, not an ASCII file, we want ADDIE continue to run (but does nothing) instead of crashing.