### PR TITLE
Update .travis.yml file for build failure issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,10 @@ cache:
 
 matrix:
   include:
+  # - os: linux
+  #   env: CONDA=2.7
   - os: linux
-    env: CONDA=2.7
-  - os: linux
-    env: CONDA=3.6.7
+    env: CONDA=3.7
 
 before_install:
 - |


### PR DESCRIPTION
Currently travis build will fail because we have the legacy Python 2.7 included in building matrix. We should get rid of Python 2.7 from the automatic build.