### PR TITLE
Multiple updates

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }} 
-          channels: marshallmcdonnell,conda-forge,mantid
+          channels: marshallmcdonnell,conda-forge,mantid,neutrons
 
       - name: Apt install deps
         run: sudo apt-get install xvfb freeglut3-dev libglu1-mesa

--- a/addie/autoNOM/make_exp_ini_file_and_run_autonom.py
+++ b/addie/autoNOM/make_exp_ini_file_and_run_autonom.py
@@ -27,6 +27,7 @@ class MakeExpIniFileAndRunAutonom(object):
         # self.parent = parent.ui
         self.parent = parent.autonom_ui
         self.folder = folder
+        self.script_to_run = "python " + parent._autonom_script + " -l -P " + parent.idl_script_dir
 
     def create(self):
         self.retrieve_metadata()
@@ -208,6 +209,7 @@ class MakeExpIniFileAndRunAutonom(object):
         _script_to_run = self.script_to_run + self.script_flag
         os.chdir(self.folder)
 
+        print("[LOG] " + _script_to_run)
         # o_gui = Step1GuiHandler(parent=self.parent_no_ui)
         o_gui = Step1GuiHandler(main_window=self.parent_no_ui)
         o_gui.set_main_window_title()

--- a/addie/autoNOM/run_step1.py
+++ b/addie/autoNOM/run_step1.py
@@ -73,9 +73,9 @@ class RunStep1(object):
 
         self._make_folder(_full_path)
         if self.run_autonom:
-            self.parent.statusbar.showMessage("Created folder: " + _full_path + " and running autoNOM script !")
+            self.parent_no_ui.ui.statusbar.showMessage("Created folder: " + _full_path + " and running autoNOM script !")
         else:
-            self.parent.statusbar.showMessage("Created folder: " + _full_path)
+            self.parent_no_ui.ui.statusbar.showMessage("Created folder: " + _full_path)
 
     def retrieve_last_incremented_index(self, list_folder):
         _list_index = []

--- a/addie/calculate_gr/event_handler.py
+++ b/addie/calculate_gr/event_handler.py
@@ -231,7 +231,9 @@ def generate_gr_step2(main_window, sq_ws_name_list):
             q_in = out_ws_temp.readX(0)
             sq_in = out_ws_temp.readY(0)
             transformer = Transformer()
-            r_in, gr_in = transformer.S_to_G(q_in, sq_in, r_in)
+            import pystog
+            print("PYSTOG:", pystog.__file__)
+            r_in, gr_in, dg_in = transformer.S_to_G(q_in, sq_in, r_in)
             ff = FourierFilter()
             r_cutoff_ff_text = main_window.calculategr_ui.lineEdit_rcutoff.text()
             try:
@@ -240,15 +242,21 @@ def generate_gr_step2(main_window, sq_ws_name_list):
                 print("WARNING: rcutoff is not a float. Necessary for applying Fourier filter.")
                 return
 
-            q_ft, sq_ft, q_out, sq_out, r_out, gr_out = ff.G_using_S(r_in, gr_in,
-                                                                     q_in, sq_in,
-                                                                     r_cutoff_ff,
-                                                                     rho=rho0)
+            q_ft, sq_ft, q_out, sq_out, r_out, gr_out, dsq_ft, dsq, dgr = ff.G_using_S(
+                r_in,
+                gr_in,
+                q_in,
+                sq_in,
+                r_cutoff_ff,
+                rho=rho0)
+
             new_sq_wks = sq_ws_name + "_ff_rcutoff_" + r_cutoff_ff_text.replace(".", "p")
-            simpleapi.CreateWorkspace(DataX=q_out, DataY=sq_out,
-                                      OutputWorkspace=new_sq_wks,
-                                      NSpec=1,
-                                      unitX="MomentumTransfer")
+            simpleapi.CreateWorkspace(
+                DataX=q_out,
+                DataY=sq_out,
+                OutputWorkspace=new_sq_wks,
+                NSpec=1,
+                unitX="MomentumTransfer")
             main_window.calculategr_ui.treeWidget_grWsList.add_sq(new_sq_wks)
             main_window.calculategr_ui.treeWidget_grWsList._workspaceNameList.append(new_sq_wks)
             plot_sq(main_window, new_sq_wks, color=None, clear_prev=False)

--- a/addie/calculate_gr/event_handler.py
+++ b/addie/calculate_gr/event_handler.py
@@ -209,24 +209,24 @@ def generate_gr_step2(main_window, sq_ws_name_list):
 
     # loop for all selected S(Q)
     for sq_ws_name in sq_ws_name_list:
+        # calculate G(r)
+        gr_ws_name = main_window._myController.calculate_gr(
+            sq_ws_name,
+            pdf_type,
+            min_r,
+            delta_r,
+            max_r,
+            min_q,
+            max_q,
+            pdf_filter,
+            rho0)
         if main_window.calculategr_ui.ff_check.checkState() == 2:
             if rho0 is None:
                 print("WARNING: rho0 is not a float. Necessary for applying meaningful Fourier filter.")
                 return
-            # calculate G(r)
-            gr_ws_name_temp = main_window._myController.calculate_gr(
-                sq_ws_name,
-                pdf_type,
-                min_r,
-                delta_r,
-                max_r,
-                min_q,
-                max_q,
-                pdf_filter,
-                rho0)
             # Fourier filter
             out_ws_temp = AnalysisDataService.retrieve(sq_ws_name)
-            out_ws_r_temp = AnalysisDataService.retrieve(gr_ws_name_temp)
+            out_ws_r_temp = AnalysisDataService.retrieve(gr_ws_name)
             r_in = out_ws_r_temp.readX(0)
             q_in = out_ws_temp.readX(0)
             sq_in = out_ws_temp.readY(0)
@@ -254,18 +254,6 @@ def generate_gr_step2(main_window, sq_ws_name_list):
             plot_sq(main_window, new_sq_wks, color=None, clear_prev=False)
             gr_ws_name = main_window._myController.calculate_gr(
                 new_sq_wks,
-                pdf_type,
-                min_r,
-                delta_r,
-                max_r,
-                min_q,
-                max_q,
-                pdf_filter,
-                rho0)
-        else:
-            # calculate G(r)
-            gr_ws_name = main_window._myController.calculate_gr(
-                sq_ws_name,
                 pdf_type,
                 min_r,
                 delta_r,

--- a/addie/calculate_gr/event_handler.py
+++ b/addie/calculate_gr/event_handler.py
@@ -7,6 +7,9 @@ import addie.utilities.workspaces
 import addie.calculate_gr.edit_sq_dialog
 from addie.calculate_gr.save_sq_dialog_message import SaveSqDialogMessageDialog
 from addie.widgets.filedialog import get_save_file
+from mantid.api import AnalysisDataService
+import mantid.simpleapi as simpleapi
+from pystog import Transformer, FourierFilter
 
 
 def check_widgets_status(main_window, enable_gr_widgets=False):
@@ -206,17 +209,71 @@ def generate_gr_step2(main_window, sq_ws_name_list):
 
     # loop for all selected S(Q)
     for sq_ws_name in sq_ws_name_list:
-        # calculate G(r)
-        gr_ws_name = main_window._myController.calculate_gr(
-            sq_ws_name,
-            pdf_type,
-            min_r,
-            delta_r,
-            max_r,
-            min_q,
-            max_q,
-            pdf_filter,
-            rho0)
+        if main_window.calculategr_ui.ff_check.checkState() == 2:
+            if rho0 is None:
+                print("WARNING: rho0 is not a float. Necessary for applying meaningful Fourier filter.")
+                return
+            # calculate G(r)
+            gr_ws_name_temp = main_window._myController.calculate_gr(
+                sq_ws_name,
+                pdf_type,
+                min_r,
+                delta_r,
+                max_r,
+                min_q,
+                max_q,
+                pdf_filter,
+                rho0)
+            # Fourier filter
+            out_ws_temp = AnalysisDataService.retrieve(sq_ws_name)
+            out_ws_r_temp = AnalysisDataService.retrieve(gr_ws_name_temp)
+            r_in = out_ws_r_temp.readX(0)
+            q_in = out_ws_temp.readX(0)
+            sq_in = out_ws_temp.readY(0)
+            transformer = Transformer()
+            r_in, gr_in = transformer.S_to_G(q_in, sq_in, r_in)
+            ff = FourierFilter()
+            r_cutoff_ff_text = main_window.calculategr_ui.lineEdit_rcutoff.text()
+            try:
+                r_cutoff_ff = float(r_cutoff_ff_text)
+            except ValueError:
+                print("WARNING: rcutoff is not a float. Necessary for applying Fourier filter.")
+                return
+
+            q_ft, sq_ft, q_out, sq_out, r_out, gr_out = ff.G_using_S(r_in, gr_in,
+                                                                     q_in, sq_in,
+                                                                     r_cutoff_ff,
+                                                                     rho=rho0)
+            new_sq_wks = sq_ws_name + "_ff_rcutoff_" + r_cutoff_ff_text.replace(".", "p")
+            simpleapi.CreateWorkspace(DataX=q_out, DataY=sq_out,
+                                      OutputWorkspace=new_sq_wks,
+                                      NSpec=1,
+                                      unitX="MomentumTransfer")
+            main_window.calculategr_ui.treeWidget_grWsList.add_sq(new_sq_wks)
+            main_window.calculategr_ui.treeWidget_grWsList._workspaceNameList.append(new_sq_wks)
+            plot_sq(main_window, new_sq_wks, color=None, clear_prev=False)
+            gr_ws_name = main_window._myController.calculate_gr(
+                new_sq_wks,
+                pdf_type,
+                min_r,
+                delta_r,
+                max_r,
+                min_q,
+                max_q,
+                pdf_filter,
+                rho0)
+        else:
+            # calculate G(r)
+            gr_ws_name = main_window._myController.calculate_gr(
+                sq_ws_name,
+                pdf_type,
+                min_r,
+                delta_r,
+                max_r,
+                min_q,
+                max_q,
+                pdf_filter,
+                rho0)
 
         # check whether G(r) is in GofR plot to either update or add new plot
         update = main_window.calculategr_ui.graphicsView_gr.has_gr(gr_ws_name)

--- a/addie/initialization/events/postprocessing_tab.py
+++ b/addie/initialization/events/postprocessing_tab.py
@@ -15,8 +15,8 @@ def run(main_window=None):
     main_window.postprocessing_ui.pushButton.clicked.connect(main_window.reset_q_range)
     main_window.postprocessing_ui.plazcek_fit_range_max.editingFinished.connect(main_window.check_plazcek_widgets)
     main_window.postprocessing_ui.plazcek_fit_range_min.editingFinished.connect(main_window.check_plazcek_widgets)
-    main_window.postprocessing_ui.hydrogen_no.clicked.connect(main_window.no_hidrogen_clicked)
-    main_window.postprocessing_ui.hydrogen_yes.clicked.connect(main_window.hidrogen_clicked)
+    main_window.postprocessing_ui.hydrogen_no.clicked.connect(main_window.no_hydrogen_clicked)
+    main_window.postprocessing_ui.hydrogen_yes.clicked.connect(main_window.hydrogen_clicked)
     main_window.postprocessing_ui.fourier_filter_from.editingFinished.connect(main_window.check_fourier_filter_widgets)
     main_window.postprocessing_ui.fourier_filter_to.editingFinished.connect(main_window.check_fourier_filter_widgets)
     main_window.postprocessing_ui.run_ndabs_output_file_name.textChanged['QString'].connect(

--- a/addie/main.py
+++ b/addie/main.py
@@ -278,6 +278,8 @@ class MainWindow(QMainWindow):
     global_key_value = {}
     align_and_focus_powder_from_files_blacklist = []
 
+    idl_modes = ("idl", "idl_dev")
+
     def __init__(self, parent=None, processing_mode=None):
         """ Initialization
         Parameters

--- a/addie/main.py
+++ b/addie/main.py
@@ -363,6 +363,16 @@ class MainWindow(QMainWindow):
         # color management
         self._pdfColorManager = PDFPlotManager()
 
+        # IDL config scripts
+        idl_script_dir = "/SNS/NOM/shared/autoNOM/stable/"
+        if self.post_processing == "idl_dev":
+            idl_script_dir = "/SNS/NOM/shared/autoNOM/dev/"
+        self.idl_script_dir = idl_script_dir
+        self._autonom_script = os.path.join(idl_script_dir, "autoNOM.py")
+        self._sum_scans_script = os.path.join(idl_script_dir, "sumscans.py")
+        self._ndabs_script = os.path.join(idl_script_dir, "NDabs.py")
+        self._is_sum_scans_python_checked = False
+
         # Connecting all the widgets
         main_tab_events_handler.run(main_window=self)
         autonom_tab_events_handler.run(main_window=self)
@@ -581,13 +591,13 @@ class MainWindow(QMainWindow):
         _o_gui = Step2GuiHandler(main_window=self)
         _o_gui.check_gui()
 
-    def hidrogen_clicked(self):
+    def hydrogen_clicked(self):
         o_gui = Step2GuiHandler(main_window=self)
-        o_gui.hidrogen_clicked()
+        o_gui.hydrogen_clicked()
 
-    def no_hidrogen_clicked(self):
+    def no_hydrogen_clicked(self):
         o_gui = Step2GuiHandler(main_window=self)
-        o_gui.no_hidrogen_clicked()
+        o_gui.no_hydrogen_clicked()
 
     def yes_background_clicked(self):
         o_gui = Step2GuiHandler(main_window=self)
@@ -996,7 +1006,8 @@ def main(config=None):
             help='Set processing mode (default=%(default)s)',
             choices=[
                 'mantid',
-                'idl'])
+                'idl',
+                'idl_dev'])
 
         try:  # set up bash completion as a soft dependency
             import argcomplete  # noqa

--- a/addie/menu/event_handler.py
+++ b/addie/menu/event_handler.py
@@ -54,7 +54,7 @@ def help_about_clicked(main_window):
 
 
 def activate_reduction_tabs(main_window):
-    if main_window.post_processing == 'idl':
+    if main_window.post_processing in ("idl", "idl_dev"):
         tab_0 = True
         tab_1 = True
         tab_2 = False

--- a/addie/menu/event_handler.py
+++ b/addie/menu/event_handler.py
@@ -54,7 +54,7 @@ def help_about_clicked(main_window):
 
 
 def activate_reduction_tabs(main_window):
-    if main_window.post_processing in ("idl", "idl_dev"):
+    if main_window.post_processing in main_window.idl_modes:
         tab_0 = True
         tab_1 = True
         tab_2 = False

--- a/addie/menu/file/settings/advanced_file_window.py
+++ b/addie/menu/file/settings/advanced_file_window.py
@@ -33,7 +33,7 @@ class AdvancedWindow(QMainWindow):
     def init_widgets(self):
         _idl_status = False
         _mantid_status = False
-        if self.parent.post_processing in ("idl", "idl_dev"):
+        if self.parent.post_processing in self.parent.idl_modes:
             _idl_status = True
         else:
             _mantid_status = True

--- a/addie/menu/file/settings/advanced_file_window.py
+++ b/addie/menu/file/settings/advanced_file_window.py
@@ -33,15 +33,19 @@ class AdvancedWindow(QMainWindow):
     def init_widgets(self):
         _idl_status = False
         _mantid_status = False
-        if self.parent.post_processing == 'idl':
+        if self.parent.post_processing in ("idl", "idl_dev"):
             _idl_status = True
         else:
             _mantid_status = True
 
-        self.ui.idl_groupbox.setVisible(self.parent.advanced_window_idl_groupbox_visible)
+        self.ui.idl_config_group_box.setVisible(self.parent.advanced_window_idl_groupbox_visible)
 
         self.ui.idl_post_processing_button.setChecked(_idl_status)
         self.ui.mantid_post_processing_button.setChecked(_mantid_status)
+        # When 'idl' or 'idl_dev' model is enabled from CLI, this should enable
+        # the setting box, etc. by default without the need for explicitly
+        # clicking on the 'IDL' radio button.
+        self.post_processing_clicked()
 
         instrument = self.parent.instrument["full_name"]
         list_instrument_full_name = self.parent.list_instrument["full_name"]
@@ -58,6 +62,12 @@ class AdvancedWindow(QMainWindow):
         self.ui.cache_dir_label.setText(self.parent.cache_folder)
         self.ui.output_dir_label.setText(self.parent.output_folder)
 
+        # IDL config
+        self.ui.autonom_path_line_edit.setText(self.parent._autonom_script)
+        self.ui.sum_scans_path_line_edit.setText(self.parent._sum_scans_script)
+        self.ui.ndabs_path_line_edit.setText(self.parent._ndabs_script)
+        self.ui.idl_config_browse_button_dialog = None
+
         self.ui.centralwidget.setContentsMargins(10, 10, 10, 10)
 
     def is_idl_selected(self):
@@ -71,7 +81,7 @@ class AdvancedWindow(QMainWindow):
             _post = 'mantid'
             _idl_groupbox_visible = False
 
-        self.ui.idl_groupbox.setVisible(_idl_groupbox_visible)
+        self.ui.idl_config_group_box.setVisible(_idl_groupbox_visible)
         self.parent.post_processing = _post
         self.parent.activate_reduction_tabs() # hide or show right tabs
         self.parent.advanced_window_idl_groupbox_visible = _idl_groupbox_visible
@@ -96,6 +106,72 @@ class AdvancedWindow(QMainWindow):
         if _output_folder:
             self.ui.output_dir_label.setText(str(_output_folder))
             self.parent.output_folder = str(_output_folder)
+
+    # IDL Config - Line Edits
+    def autonom_path_line_edited(self):
+        """ update autonom script in top-level after line editing """
+        _script = str(self.ui.autonom_path_line_edit.text())
+        self.parent._autonom_script = _script
+
+    def sum_scans_path_line_edited(self):
+        """ update sum scans script in top-level after line editing """
+        _script = str(self.ui.sum_scans_path_line_edit.text())
+        self.parent._sum_scans_script = _script
+
+    def ndabs_path_line_edited(self):
+        """ update ndabs script in top-level after line editing """
+        _script = str(self.ui.ndabs_path_line_edit.text())
+        self.parent._ndabs_script = _script
+
+    # IDL Config - Browse Buttons
+    def _idl_button_clicked(self, line_edit):
+        """ Utility function to handle IDL script path browse buttons """
+
+        # Initialize with current script in line edit
+        script = str(line_edit.text())
+
+        # Get current working directory to open file dialog in
+        _current_folder = self.parent.current_folder
+
+        # Launch file dialog
+        self.ui.idl_config_browse_button_dialog = QFileDialog(
+            parent=self.ui,
+            directory=_current_folder,
+            caption="Select File",
+            filter=("Python (*.py);; All Files (*.*)"))
+
+        # Handle if we select a file or cancel
+        if self.ui.idl_config_browse_button_dialog.exec_():
+            files = self.ui.idl_config_browse_button_dialog.selectedFiles()
+
+            if files[0] != '':
+                script = str(files[0])
+                line_edit.setText(script)
+
+        # Set the class attribute back to None for monitoring / testing
+        self.ui.idl_config_browse_button_dialog = None
+
+        return script
+
+    def autonom_path_browse_button_clicked(self):
+        """ Handle browse button clicked for autonom script path """
+        line_edit = self.ui.autonom_path_line_edit
+        self.parent._autonom_script = self._idl_button_clicked(line_edit)
+
+    def sum_scans_path_browse_button_clicked(self):
+        """ Handle browse button clicked for sum scans script path """
+        line_edit = self.ui.sum_scans_path_line_edit
+        self.parent._sum_scans_script = self._idl_button_clicked(line_edit)
+
+    def ndabs_path_browse_button_clicked(self):
+        """ Handle browse button clicked for ndabs script path """
+        line_edit = self.ui.ndabs_path_line_edit
+        self.parent._ndabs_script = self._idl_button_clicked(line_edit)
+
+    def sum_scans_python_version_checkbox_toggled(self):
+        """ Handle the sum scans checkbox for using the python version """
+        _is_checked = self.ui.sum_scans_python_version_checkbox.isChecked()
+        self.parent._is_sum_scans_python_checked = _is_checked
 
     def closeEvent(self, c):
         self.parent.advanced_window_ui = None

--- a/addie/processing/idl/run_sum_scans.py
+++ b/addie/processing/idl/run_sum_scans.py
@@ -6,13 +6,19 @@ from addie.processing.idl.step2_gui_handler import Step2GuiHandler
 
 class RunSumScans(object):
 
-    script = 'python  /SNS/NOM/shared/autoNOM/stable/sumscans.py '
     output_file = ''
 
     def __init__(self, parent=None):
         self.parent = parent.ui.postprocessing_ui
         self.parent_no_ui = parent
+        self.o_gui_handler = Step2GuiHandler(main_window=self.parent_no_ui)
         self.folder = os.getcwd()
+        self.set_sum_scans_script()
+
+    def set_sum_scans_script(self):
+        self.script_path = self.o_gui_handler.get_sum_scans_script()
+        self.script = 'python ' + self.script_path
+        print("SumScans: ", self.script)
 
     def run(self):
         self._background = self.collect_background_runs()
@@ -30,12 +36,13 @@ class RunSumScans(object):
         print("[LOG] " + _script_to_run)
 
     def add_script_flags(self):
+        self.set_sum_scans_script()
         _script = self.script
 
         if not self.parent.interactive_mode_checkbox.isChecked():
-            _script += "-n True"
-        if self.parent.pytest.isChecked():
-            _script += "-u True"
+            _script += " -n True "
+        if self.parent_no_ui._is_sum_scans_python_checked:
+            _script += " -u True "
 
         qmax_list = str(self.parent.pdf_qmax_line_edit.text()).strip()
         if not (qmax_list == ""):
@@ -45,9 +52,9 @@ class RunSumScans(object):
 
     def create_output_file(self):
         _output_file_name = "sum_" + self.parent.sum_scans_output_file_name.text() + ".inp"
-#        print("_output_file_name: {}".format(_output_file_name))
+        # print("_output_file_name: {}".format(_output_file_name))
         _full_output_file_name = os.path.join(self.folder, _output_file_name)
- #       print("_full_output_file_name: {}".format(_full_output_file_name))
+        # print("_full_output_file_name: {}".format(_full_output_file_name))
         self.full_output_file_name = _full_output_file_name
 
         f = open(_full_output_file_name, 'w')
@@ -61,7 +68,7 @@ class RunSumScans(object):
 
         # hydrogen flag
         plattype_flag = 0
-        if o_gui_handler.is_hidrogen_clicked():
+        if o_gui_handler.is_hydrogen_clicked():
             plattype_flag = 2
         f.write("platype {}\n".format(plattype_flag))
 

--- a/addie/processing/idl/step2_gui_handler.py
+++ b/addie/processing/idl/step2_gui_handler.py
@@ -34,14 +34,14 @@ class Step2GuiHandler(object):
             self.main_window.current_folder = _new_folder
             self.main_window.setWindowTitle(_new_folder)
 
-    def is_hidrogen_clicked(self):
+    def is_hydrogen_clicked(self):
         return self.main_window.postprocessing_ui.hydrogen_yes.isChecked()
 
-    def hidrogen_clicked(self):
+    def hydrogen_clicked(self):
         _range = self.hidrogen_range
         self.populate_hidrogen_range(_range)
 
-    def no_hidrogen_clicked(self):
+    def no_hydrogen_clicked(self):
         _range = self.no_hidrogen_range
         self.populate_hidrogen_range(_range)
 
@@ -112,6 +112,9 @@ class Step2GuiHandler(object):
         else:
             _output_file_name = self.default_ndabs_output_file_name
         return _output_file_name
+
+    def get_sum_scans_script(self):
+        return self.main_window._sum_scans_script
 
     def check_import_export_buttons(self):
         _export_status = False

--- a/addie/processing/idl/table_handler.py
+++ b/addie/processing/idl/table_handler.py
@@ -90,7 +90,8 @@ class TableHandler(object):
         _refresh_table = -1
         _clear_table = -1
         # _import = -1
-        # _export = -1        _check_all = -1
+        # _export = -1
+        _check_all = -1
         _uncheck_all = -1
         _undo = -1
         _redo = -1

--- a/addie/ui/advanced_window.ui
+++ b/addie/ui/advanced_window.ui
@@ -226,29 +226,82 @@
      </spacer>
     </item>
     <item>
-     <widget class="QGroupBox" name="idl_groupbox">
+     <widget class="QGroupBox" name="idl_config_group_box">
       <property name="title">
-       <string/>
+       <string>IDL Reduction Config</string>
       </property>
-      <layout class="QVBoxLayout" name="verticalLayout">
+      <layout class="QVBoxLayout" name="verticalLayout_2">
        <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_6">
+        <layout class="QVBoxLayout" name="verticalLayout_4">
          <item>
-          <widget class="QLabel" name="label_3">
+          <layout class="QHBoxLayout" name="horizontalLayout_7">
+           <item>
+            <widget class="QLabel" name="autonom_path_label">
+             <property name="text">
+              <string>autNOM: </string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLineEdit" name="autonom_path_line_edit"/>
+           </item>
+           <item>
+            <widget class="QPushButton" name="autonom_path_browse_button">
+             <property name="text">
+              <string>Browse ...</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_6">
+           <item>
+            <widget class="QLabel" name="sum_scans_path_label">
+             <property name="text">
+              <string>Sum Scans: </string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLineEdit" name="sum_scans_path_line_edit"/>
+           </item>
+           <item>
+            <widget class="QPushButton" name="sum_scans_path_browse_button">
+             <property name="text">
+              <string>Browse ...</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="sum_scans_python_version_checkbox">
            <property name="text">
-            <string>TextLabel</string>
+            <string>Use Sum Scans Python Version?</string>
            </property>
           </widget>
          </item>
          <item>
-          <widget class="QLineEdit" name="lineEdit"/>
-         </item>
-         <item>
-          <widget class="QPushButton" name="pushButton">
-           <property name="text">
-            <string>Browse ...</string>
-           </property>
-          </widget>
+          <layout class="QHBoxLayout" name="horizontalLayout_8">
+           <item>
+            <widget class="QLabel" name="ndabs_path_label">
+             <property name="text">
+              <string>NDabs:  </string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLineEdit" name="ndabs_path_line_edit"/>
+           </item>
+           <item>
+            <widget class="QPushButton" name="ndabs_path_browse_button">
+             <property name="text">
+              <string>Browse ...</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
          </item>
         </layout>
        </item>
@@ -263,7 +316,7 @@
      <x>0</x>
      <y>0</y>
      <width>939</width>
-     <height>23</height>
+     <height>20</height>
     </rect>
    </property>
   </widget>
@@ -278,8 +331,8 @@
    <slot>post_processing_clicked()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>143</x>
-     <y>149</y>
+     <x>134</x>
+     <y>232</y>
     </hint>
     <hint type="destinationlabel">
      <x>194</x>
@@ -294,8 +347,8 @@
    <slot>post_processing_clicked()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>83</x>
-     <y>149</y>
+     <x>84</x>
+     <y>232</y>
     </hint>
     <hint type="destinationlabel">
      <x>196</x>
@@ -327,7 +380,7 @@
    <hints>
     <hint type="sourcelabel">
      <x>175</x>
-     <y>227</y>
+     <y>403</y>
     </hint>
     <hint type="destinationlabel">
      <x>562</x>
@@ -343,11 +396,123 @@
    <hints>
     <hint type="sourcelabel">
      <x>175</x>
-     <y>261</y>
+     <y>436</y>
     </hint>
     <hint type="destinationlabel">
      <x>124</x>
      <y>209</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>autonom_path_line_edit</sender>
+   <signal>editingFinished()</signal>
+   <receiver>MainWindow</receiver>
+   <slot>autonom_path_line_edited()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>189</x>
+     <y>612</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>209</x>
+     <y>488</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>sum_scans_path_line_edit</sender>
+   <signal>editingFinished()</signal>
+   <receiver>MainWindow</receiver>
+   <slot>sum_scans_path_line_edited()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>200</x>
+     <y>644</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>218</x>
+     <y>515</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>ndabs_path_line_edit</sender>
+   <signal>editingFinished()</signal>
+   <receiver>MainWindow</receiver>
+   <slot>ndabs_path_line_edited()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>208</x>
+     <y>697</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>228</x>
+     <y>538</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>autonom_path_browse_button</sender>
+   <signal>clicked()</signal>
+   <receiver>MainWindow</receiver>
+   <slot>autonom_path_browse_button_clicked()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>896</x>
+     <y>616</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>880</x>
+     <y>481</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>sum_scans_path_browse_button</sender>
+   <signal>clicked()</signal>
+   <receiver>MainWindow</receiver>
+   <slot>sum_scans_path_browse_button_clicked()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>857</x>
+     <y>648</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>848</x>
+     <y>504</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>ndabs_path_browse_button</sender>
+   <signal>clicked()</signal>
+   <receiver>MainWindow</receiver>
+   <slot>ndabs_path_browse_button_clicked()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>853</x>
+     <y>709</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>812</x>
+     <y>529</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>sum_scans_python_version_checkbox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>MainWindow</receiver>
+   <slot>sum_scans_python_version_checkbox_toggled()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>30</x>
+     <y>676</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>60</x>
+     <y>485</y>
     </hint>
    </hints>
   </connection>
@@ -359,5 +524,12 @@
   <slot>output_dir_button_clicked()</slot>
   <slot>add_key_value()</slot>
   <slot>remove_key_value_selected()</slot>
+  <slot>ndabs_path_line_edited()</slot>
+  <slot>autonom_path_line_edited()</slot>
+  <slot>sum_scans_path_line_edited()</slot>
+  <slot>autonom_path_browse_button_clicked()</slot>
+  <slot>sum_scans_path_browse_button_clicked()</slot>
+  <slot>ndabs_path_browse_button_clicked()</slot>
+  <slot>sum_scans_python_version_checkbox_toggled()</slot>
  </slots>
 </ui>

--- a/addie/ui/mainWindow.ui
+++ b/addie/ui/mainWindow.ui
@@ -450,8 +450,8 @@
   <slot>run_ndabs_clicked()</slot>
   <slot>populate_table_clicked()</slot>
   <slot>check_plazcek_widgets()</slot>
-  <slot>hidrogen_clicked()</slot>
-  <slot>no_hidrogen_clicked()</slot>
+  <slot>hydrogen_clicked()</slot>
+  <slot>no_hydrogen_clicked()</slot>
   <slot>check_fourier_filter_widgets()</slot>
   <slot>create_sample_properties_files_clicked()</slot>
   <slot>yes_background_clicked()</slot>

--- a/addie/ui/old_mainWindow.ui
+++ b/addie/ui/old_mainWindow.ui
@@ -5946,7 +5946,7 @@ p, li { white-space: pre-wrap; }
    <sender>hydrogen_no</sender>
    <signal>clicked()</signal>
    <receiver>MainWindow</receiver>
-   <slot>no_hidrogen_clicked()</slot>
+   <slot>no_hydrogen_clicked()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>1107</x>
@@ -6026,7 +6026,7 @@ p, li { white-space: pre-wrap; }
    <sender>hydrogen_yes</sender>
    <signal>clicked()</signal>
    <receiver>MainWindow</receiver>
-   <slot>hidrogen_clicked()</slot>
+   <slot>hydrogen_clicked()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>937</x>
@@ -6452,8 +6452,8 @@ p, li { white-space: pre-wrap; }
   <slot>run_ndabs_clicked()</slot>
   <slot>populate_table_clicked()</slot>
   <slot>check_plazcek_widgets()</slot>
-  <slot>hidrogen_clicked()</slot>
-  <slot>no_hidrogen_clicked()</slot>
+  <slot>hydrogen_clicked()</slot>
+  <slot>no_hydrogen_clicked()</slot>
   <slot>check_fourier_filter_widgets()</slot>
   <slot>create_sample_properties_files_clicked()</slot>
   <slot>yes_background_clicked()</slot>

--- a/addie/ui/processing_tab.ui
+++ b/addie/ui/processing_tab.ui
@@ -988,8 +988,8 @@
   <slot>run_ndabs_clicked()</slot>
   <slot>populate_table_clicked()</slot>
   <slot>check_plazcek_widgets()</slot>
-  <slot>hidrogen_clicked()</slot>
-  <slot>no_hidrogen_clicked()</slot>
+  <slot>hydrogen_clicked()</slot>
+  <slot>no_hydrogen_clicked()</slot>
   <slot>check_fourier_filter_widgets()</slot>
   <slot>create_sample_properties_files_clicked()</slot>
   <slot>yes_background_clicked()</slot>

--- a/addie/ui/splitui_calculategr_tab.ui
+++ b/addie/ui/splitui_calculategr_tab.ui
@@ -381,10 +381,17 @@
           </item>
           <item>
            <layout class="QGridLayout" name="gridLayout_2">
-            <item row="2" column="1">
-             <widget class="QComboBox" name="comboBox_pdfCorrection"/>
+            <item row="1" column="0">
+             <widget class="QCheckBox" name="ff_check">
+              <property name="enabled">
+               <bool>true</bool>
+              </property>
+              <property name="text">
+               <string>Fourier Filter</string>
+              </property>
+             </widget>
             </item>
-            <item row="1" column="1">
+            <item row="1" column="3">
              <widget class="QLineEdit" name="lineEdit_rho">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
@@ -394,24 +401,7 @@
               </property>
              </widget>
             </item>
-            <item row="2" column="0">
-             <widget class="QLabel" name="label_filter">
-              <property name="font">
-               <font>
-                <pointsize>10</pointsize>
-                <weight>75</weight>
-                <bold>true</bold>
-               </font>
-              </property>
-              <property name="text">
-               <string>Filter</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="0">
+            <item row="1" column="2">
              <layout class="QHBoxLayout" name="horizontalLayout_18">
               <item>
                <widget class="QLabel" name="label_4">
@@ -434,6 +424,57 @@
                </widget>
               </item>
              </layout>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QGridLayout" name="gridLayout_2_1">
+            <item row="1" column="3">
+             <widget class="QComboBox" name="comboBox_pdfCorrection"/>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="label_filter">
+              <property name="font">
+               <font>
+                <pointsize>10</pointsize>
+                <weight>75</weight>
+                <bold>true</bold>
+               </font>
+              </property>
+              <property name="text">
+               <string>Rcutoff</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignLeft|Qt::AlignVCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QLineEdit" name="lineEdit_rcutoff">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
+                <horstretch>1</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="2">
+             <widget class="QLabel" name="label_filter">
+              <property name="font">
+               <font>
+                <pointsize>10</pointsize>
+                <weight>75</weight>
+                <bold>true</bold>
+               </font>
+              </property>
+              <property name="text">
+               <string>Filter</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+             </widget>
             </item>
            </layout>
           </item>

--- a/addie/ui/step2.ui
+++ b/addie/ui/step2.ui
@@ -811,7 +811,7 @@
    <sender>hydrogen_yes</sender>
    <signal>clicked()</signal>
    <receiver>MainWindow</receiver>
-   <slot>hidrogen_clicked()</slot>
+   <slot>hydrogen_clicked()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>785</x>
@@ -827,7 +827,7 @@
    <sender>hydrogen_no</sender>
    <signal>clicked()</signal>
    <receiver>MainWindow</receiver>
-   <slot>no_hidrogen_clicked()</slot>
+   <slot>no_hydrogen_clicked()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>868</x>
@@ -986,8 +986,8 @@
  </connections>
  <slots>
   <slot>populate_table_clicked()</slot>
-  <slot>hidrogen_clicked()</slot>
-  <slot>no_hidrogen_clicked()</slot>
+  <slot>hydrogen_clicked()</slot>
+  <slot>no_hydrogen_clicked()</slot>
   <slot>no_background_clicked()</slot>
   <slot>yes_background_clicked()</slot>
   <slot>background_combobox_changed()</slot>

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -19,6 +19,7 @@ requirements:
     - periodictable
     - psutil
     - python
+    - pystog
     - setuptools
     - simplejson
 
@@ -29,6 +30,7 @@ requirements:
     - periodictable
     - psutil
     - python
+    - pystog
     - simplejson
 
 test:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 periodictable
 psutil==5.8
+pystog==0.3.0
 qtpy==1.6
 simplejson==3.17


### PR DESCRIPTION
It will be very nice if either of you @peterfpeterson @marshallmcdonnell can help reviewing this PR and make a `next` release of ADDIE. Here following is details about my implementation.

1. Fourier filter capability added in.

    1.1. Implemented with `pystog`,so may need to update the installation dependency list to include the conda package for `pystog`: [https://anaconda.org/neutrons/pystog](https://anaconda.org/neutrons/pystog).

    1.2. Checkbox added in the GUI (under `Calculate G(r)` tab) to control whether or not to enable the Fourier filter.

    1.3. `rcutoff`input box added for users to provide the cutoff in real space for conducting the Fourier filter.

    1.4. The number density value is read in from the `rho0` input box.

    1.5. Either `rho0` or `rcutoff` input box contains illegal value, warning message will be printed out to terminal and handle will be returned to the GUI.

2. CLI option (`--mode idl_dev`) added to enable ADDIE to use the development version of underlying scripts (which will be updated from time to time by Joerg). Here for the implementation, we follow that given in branch `addie_several_updates`: [https://github.com/neutrons/addie/tree/102_python_sumscans](https://github.com/neutrons/addie/tree/102_python_sumscans). This enables users to configure the path holding those underlying scripts from within the advanced settings window. When `--mode idl_dev` is attached as CLI argument, the default paths presented in the advanced window will be updated to the development path (instead of the stable path) automatically.

3. Typo in codes fixed - `hidrogen` => `hydrogen`.

4. Bug fixed.

    > When `Create New autoNOM Folder` checkbox is checked in `autoNOM` tab, running `Run autoNOM script` will bump into error and crash ADDIE. This has been fixed in current branch.