### PR TITLE
Drop pystog version to 0.2.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 periodictable
 psutil==5.8
-pystog==0.3.0
+pystog==0.2.7
 qtpy==1.6
 simplejson==3.17


### PR DESCRIPTION
This is simply to help the deployment to the analysis cluster since IDL reduction is stuck on Python 2.
