### PR TITLE
Unpin requirements in install and dev dependencies

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -31,7 +31,9 @@ jobs:
           channels: marshallmcdonnell,conda-forge,mantid,neutrons
 
       - name: Apt install deps
-        run: sudo apt-get install xvfb freeglut3-dev libglu1-mesa
+        run: |
+          sudo apt update
+          sudo apt-get install xvfb freeglut3-dev libglu1-mesa
 
       - name: Conda install deps
         shell: bash -l {0}

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Conda install deps
         shell: bash -l {0}
         run: |
-          conda install -c conda-forge nexus
-          conda install -c conda-forge poco
+          conda install -c conda-forge nexus==4.4.3
+          conda install -c conda-forge poco==1.7.3
           conda install mantid-workbench
           conda install mantid-total-scattering-python-wrapper
           conda install --file requirements.txt --file requirements-dev.txt

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -38,6 +38,8 @@ jobs:
       - name: Conda install deps
         shell: bash -l {0}
         run: |
+          conda install -c conda-forge nexus
+          conda install -c conda-forge poco
           conda install mantid-workbench
           conda install mantid-total-scattering-python-wrapper
           conda install --file requirements.txt --file requirements-dev.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
 flake8
 mock
-pytest==6.2
-pytest-mpl==0.12
-pytest-qt==3.3
-simplejson==3.17
+pytest
+pytest-mpl
+pytest-qt
 typing

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 periodictable
-psutil==5.8
-pystog==0.2.7
-qtpy==1.6
-simplejson==3.17
+psutil
+pystog
+qtpy
+simplejson


### PR DESCRIPTION
Having an issue in installing the conda package where the pinned requirements cause a crash due to a mismatch, even to the bug / patch version.

```
Traceback (most recent call last):
  File "/SNS/software/addie/miniconda2/envs/addie-dev/lib/python3.6/site-packages/pkg_resources/__init__.py", line 584, in _build_master
    ws.require(__requires__)
  File "/SNS/software/addie/miniconda2/envs/addie-dev/lib/python3.6/site-packages/pkg_resources/__init__.py", line 906, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/SNS/software/addie/miniconda2/envs/addie-dev/lib/python3.6/site-packages/pkg_resources/__init__.py", line 795, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (simplejson 3.17.2 (/SNS/software/addie/miniconda2/envs/addie-dev/lib/python3.6/site-packages), Requirement.parse('simplejson==3.17'), {'addie'})

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/SNS/software/addie/miniconda2/envs/addie-dev/bin/addie", line 15, in <module>
    from pkg_resources import load_entry_point
  File "/SNS/software/addie/miniconda2/envs/addie-dev/lib/python3.6/site-packages/pkg_resources/__init__.py", line 3274, in <module>
    @_call_aside
  File "/SNS/software/addie/miniconda2/envs/addie-dev/lib/python3.6/site-packages/pkg_resources/__init__.py", line 3258, in _call_aside
    f(*args, **kwargs)
  File "/SNS/software/addie/miniconda2/envs/addie-dev/lib/python3.6/site-packages/pkg_resources/__init__.py", line 3287, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/SNS/software/addie/miniconda2/envs/addie-dev/lib/python3.6/site-packages/pkg_resources/__init__.py", line 586, in _build_master
    return cls._build_from_requirements(__requires__)
  File "/SNS/software/addie/miniconda2/envs/addie-dev/lib/python3.6/site-packages/pkg_resources/__init__.py", line 599, in _build_from_requirements
    dists = ws.resolve(reqs, Environment())
  File "/SNS/software/addie/miniconda2/envs/addie-dev/lib/python3.6/site-packages/pkg_resources/__init__.py", line 787, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'simplejson==3.17' distribution was not found and is required by addie
```

Unpinning the requirements in hopes to remedy error