### PR TITLE
Adds removing default channel in conda ci setup

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Conda install deps
         shell: bash -l {0}
         run: |
+          conda config --remove channels defaults
           conda install -c conda-forge nexus==4.4.3
           conda install -c conda-forge poco==1.7.3
           conda install mantid-workbench


### PR DESCRIPTION
Trying to help the install of mantid-workbench.

From a previous try to release v5.0.12, we were getting [errors for the install caught in the tests in CI/CD](https://github.com/neutrons/addie/runs/1738868687?check_suite_focus=true) when the [exact same setup worked in the commit to master in CI/CD](https://github.com/neutrons/addie/actions/runs/499754791).

Investigating showed that some of the libraries were getting pulled from `defaults` channel:
 - `gstreamer`
 - `matplotlib`
 - `qt` ( <- probably the culprit based on error in tests)