### PR TITLE
multiple patches for table population for mantid interface

### DIFF
--- a/addie/databases/oncat/oncat.py
+++ b/addie/databases/oncat/oncat.py
@@ -84,7 +84,7 @@ def pyoncatGetIptsList(oncat=None,
         instrument=instrument,
         projection=['id']
     )
-    return [ipts.name for ipts in ipts_list]
+    return [ipts.id for ipts in ipts_list]
 
 # if __name__ == "__main__":
 #     useRcFile = True

--- a/addie/main.py
+++ b/addie/main.py
@@ -77,7 +77,6 @@ from addie.initialization.events import calculategr_tab as calculategr_tab_event
 from addie.rietveld import event_handler as rietveld_event_handler
 from addie.calculate_gr import event_handler as calculategr_event_handler
 
-from addie.processing.mantid.master_table.table_tree_handler import TableConfig
 
 class MainWindow(QMainWindow):
     """ Main addie window

--- a/addie/main.py
+++ b/addie/main.py
@@ -77,6 +77,7 @@ from addie.initialization.events import calculategr_tab as calculategr_tab_event
 from addie.rietveld import event_handler as rietveld_event_handler
 from addie.calculate_gr import event_handler as calculategr_event_handler
 
+from addie.processing.mantid.master_table.table_tree_handler import TableConfig
 
 class MainWindow(QMainWindow):
     """ Main addie window
@@ -210,6 +211,8 @@ class MainWindow(QMainWindow):
                                'list_column': [],
                                'row': [],
                                }
+    table_inserted_row = -1
+    copied_row = -1
 
     table_headers = {'h1': [],
                      'h2': [],

--- a/addie/processing/mantid/master_table/import_from_database/data_to_import_handler.py
+++ b/addie/processing/mantid/master_table/import_from_database/data_to_import_handler.py
@@ -34,7 +34,8 @@ class DataToImportHandler:
         if self.is_with_filter():
             # work only with filtered runs
             list_of_rows_to_load = list(self.parent.list_of_rows_with_global_rule)
-
+        elif self.parent.ui.name_search.text() is not None or self.parent.ui.name_search.text() != "":
+            list_of_rows_to_load = self.parent.list_row_to_show
         else:
             # work with entire stack of runs
             nbr_rows = self.parent.ui.tableWidget_all_runs.rowCount()

--- a/addie/processing/mantid/master_table/import_from_database/import_from_database_handler.py
+++ b/addie/processing/mantid/master_table/import_from_database/import_from_database_handler.py
@@ -123,9 +123,6 @@ class ImportFromDatabaseWindow(QMainWindow):
         self.ui.ipts_combobox.addItems(list_ipts)
 
     def init_widgets(self):
-        if self.parent.oncat is None:
-            return
-
         self.ui.tableWidget.setColumnHidden(0, True)
 
         self.ui.error_message.setStyleSheet("color: red")
@@ -137,6 +134,11 @@ class ImportFromDatabaseWindow(QMainWindow):
 
         self.ui.search_logo_label.setPixmap(QtGui.QPixmap(":/MPL Toolbar/search_icon.png"))
         self.ui.clear_search_button.setIcon(QtGui.QIcon(":/MPL Toolbar/clear_icon.png"))
+
+        # With this verification sitting on the top of currnet method, all icons
+        # above will fail to load at first launching.
+        if self.parent.oncat is None:
+            return
 
         for _col, _width in enumerate(self.filter_column_widths):
             self.ui.tableWidget.setColumnWidth(_col, _width)
@@ -480,6 +482,8 @@ class ImportFromDatabaseWindow(QMainWindow):
         o_search = TableSearchEngine(table_ui=self.ui.tableWidget_all_runs)
         list_row_matching_string = o_search.locate_string(new_text)
 
+        self.list_row_to_show = list_row_matching_string
+
         o_table = TableHandler(table_ui=self.ui.tableWidget_all_runs)
         o_table.show_list_of_rows(list_of_rows=list_row_matching_string)
 
@@ -490,7 +494,7 @@ class ImportFromDatabaseWindow(QMainWindow):
     def toolbox_changed(self, index):
         if index == 0:
             self.nexus_json = {}
-            self.ui.import_button.setText("Import All Runs")
+            self.ui.import_button.setText("Import All Listed Runs")
         elif index == 1:
             self.ui.import_button.setText("Import Filtered Runs")
             self.refresh_filter_page()

--- a/addie/processing/mantid/master_table/selection_handler.py
+++ b/addie/processing/mantid/master_table/selection_handler.py
@@ -250,8 +250,15 @@ class RowsHandler(SelectionHandlerMaster):
                 self.parent.ui.statusbar.showMessage(
                     "Please select only 1 row!", self.parent.statusbar_display_time)
                 return
+            elif len(list_row) == 0:
+                self.parent.ui.statusbar.setStyleSheet("color: red")
+                self.parent.ui.statusbar.showMessage(
+                    "Please select a row to copy from!", self.parent.statusbar_display_time)
+                return
 
             row = list_row[0]
+
+        self.parent.copied_row = row
 
         _table_ui = self.table_ui
         nbr_col = _table_ui.columnCount()
@@ -259,7 +266,7 @@ class RowsHandler(SelectionHandlerMaster):
         _table_ui.setRangeSelected(_row_selection, True)
         self.parent.ui.statusbar.setStyleSheet("color: green")
         self.parent.ui.statusbar.showMessage(
-            "Select another row to copy the current selected row!",
+            "Select another row to copy the current selected row to!",
             self.parent.statusbar_display_time)
 
         self.parent.master_table_cells_copy['temp'] = []
@@ -285,6 +292,11 @@ class RowsHandler(SelectionHandlerMaster):
         nbr_col = self.table_ui.columnCount()
         o_copy = CopyCells(parent=self.parent)
         list_column_copy = np.arange(0, nbr_col)
+        msg = "No row(s) selected. Highlight any cell(s) in row(s) to duplicate followed by right click."
+        if not rows_selected(list_to_row, msg):
+            self.parent.ui.statusbar.setStyleSheet("color: red")
+            self.parent.ui.statusbar.showMessage(msg, self.parent.statusbar_display_time)
+            return
         for _row in list_to_row:
             for _column in list_column_copy:
                 o_copy.copy_from_to(from_row=from_row,
@@ -294,6 +306,14 @@ class RowsHandler(SelectionHandlerMaster):
     def remove(self, row=None):
         if row is None:
             list_to_row = self.o_selection.get_list_row()
+            # if len(list_to_row) == 0:
+            #     print("[Info] No row(s) selected! Highlight any cell(s) in row(s) to remove followed by right click.")
+            #     return
+            msg = "No row(s) selected! Highlight any cell(s) in row(s) to remove followed by right click."
+            if not rows_selected(list_to_row, msg):
+                self.parent.ui.statusbar.setStyleSheet("color: red")
+                self.parent.ui.statusbar.showMessage(msg, self.parent.statusbar_display_time)
+                return
             _first_row = list_to_row[0]
             for _ in list_to_row:
                 self.remove(row=_first_row)
@@ -386,6 +406,13 @@ class CellsHandler(SelectionHandlerMaster):
         list_row = self.o_selection.get_list_row()
         nbr_row = len(list_row)
 
+        if len(list_row) == 0:
+            msg = "No cells selected! Highlight columns in the same row followed by right click."
+            self.parent.ui.statusbar.setStyleSheet("color: red")
+            self.parent.ui.statusbar.showMessage(msg, self.parent.statusbar_display_time)
+            print("[Info] " + msg)
+            return
+
         if nbr_row > 1:
             self.parent.ui.statusbar.setStyleSheet("color: red")
             self.parent.ui.statusbar.showMessage(
@@ -429,7 +456,7 @@ class CellsHandler(SelectionHandlerMaster):
         if list_column_copy[0] != list_column_paste[0]:
             self.parent.ui.statusbar.setStyleSheet("color: red")
             self.parent.ui.statusbar.showMessage(
-                "Copy and Paste first column selected do not match!",
+                "The first column selected for Copy and Paste does not match!",
                 self.parent.statusbar_display_time)
             return
 
@@ -661,3 +688,9 @@ class TableHandler(SelectionHandlerMaster):
     def clear_search(self):
         self.parent.processing_ui.name_search_3.setText("")
         self.search("")
+
+def rows_selected(selected_rows, message):
+    if len(selected_rows) == 0 or any([item < 0 for item in selected_rows]):
+        print("[Info] " + message)
+        return False
+    return True

--- a/addie/processing/mantid/master_table/selection_handler.py
+++ b/addie/processing/mantid/master_table/selection_handler.py
@@ -306,9 +306,6 @@ class RowsHandler(SelectionHandlerMaster):
     def remove(self, row=None):
         if row is None:
             list_to_row = self.o_selection.get_list_row()
-            # if len(list_to_row) == 0:
-            #     print("[Info] No row(s) selected! Highlight any cell(s) in row(s) to remove followed by right click.")
-            #     return
             msg = "No row(s) selected! Highlight any cell(s) in row(s) to remove followed by right click."
             if not rows_selected(list_to_row, msg):
                 self.parent.ui.statusbar.setStyleSheet("color: red")

--- a/addie/processing/mantid/master_table/selection_handler.py
+++ b/addie/processing/mantid/master_table/selection_handler.py
@@ -689,6 +689,7 @@ class TableHandler(SelectionHandlerMaster):
         self.parent.processing_ui.name_search_3.setText("")
         self.search("")
 
+
 def rows_selected(selected_rows, message):
     if len(selected_rows) == 0 or any([item < 0 for item in selected_rows]):
         print("[Info] " + message)

--- a/addie/processing/mantid/master_table/table_row_handler.py
+++ b/addie/processing/mantid/master_table/table_row_handler.py
@@ -20,6 +20,8 @@ from addie.processing.mantid.master_table.tree_definition import (INDEX_OF_COLUM
 
 class TableRowHandler:
 
+    inserted_row = -1
+
     def __init__(self, main_window=None):
         self.main_window = main_window
         self.table_ui = main_window.processing_ui.h3_table
@@ -27,6 +29,7 @@ class TableRowHandler:
     def insert_blank_row(self):
         row = self._calculate_insert_row()
         self.insert_row(row=row)
+        self.inserted_row = row
 
     def transfer_widget_states(self, from_key=None, data_type='sample'):
         o_transfer = TransferH3TableWidgetState(parent=self.main_window)

--- a/addie/processing/mantid/master_table/table_tree_handler.py
+++ b/addie/processing/mantid/master_table/table_tree_handler.py
@@ -75,7 +75,7 @@ class TableInitialization:
 
         _table_config = TableConfig(main_window=self.main_window)
         current_config = _table_config.get_current_config()
- 
+
         inside_dict = OrderedDict()
         inside_dict['table'] = current_config
         inside_dict['active'] = False

--- a/addie/processing/mantid/master_table/table_tree_handler.py
+++ b/addie/processing/mantid/master_table/table_tree_handler.py
@@ -18,6 +18,7 @@ from addie.processing.mantid.master_table.selection_handler import CellsHandler,
 from addie.processing.mantid.master_table.master_table_loader import TableFileLoader
 from addie.processing.mantid.master_table.master_table_exporter import TableFileExporter
 from addie.widgets.filedialog import get_save_file
+from addie.processing.mantid.master_table.selection_handler import rows_selected as rows_selected_valid
 try:
     from addie.processing.mantid.master_table.import_from_database.oncat_authentication_handler import OncatAuthenticationHandler
     import pyoncat  # noqa
@@ -71,6 +72,15 @@ class TableInitialization:
 
         self.make_tree_of_column_references()
         self.save_parameters()
+
+        _table_config = TableConfig(main_window=self.main_window)
+        current_config = _table_config.get_current_config()
+        
+        inside_dict = OrderedDict()
+        inside_dict['table'] = current_config
+        inside_dict['active'] = False
+
+        self.main_window.reset_config_dict = inside_dict
 
     def init_signals(self):
         self.main_window.h1_header_table.sectionResized.connect(
@@ -776,13 +786,21 @@ class H3TableHandler:
     def rows_copy(self):
         '''copy entire row'''
         o_rows = RowsHandler(parent=self.main_window)
+        o_rows.parent.table_inserted_row = -1
+        o_rows.parent.copied_row = -1
         o_rows.copy()
         self.check_status_of_right_click_buttons()
 
     def rows_paste(self):
         '''paste entire row'''
         o_rows = RowsHandler(parent=self.main_window)
-        o_rows.paste()
+        if o_rows.parent.table_inserted_row == -1:
+            o_rows.paste()
+        else:
+            if o_rows.parent.table_inserted_row <= o_rows.parent.copied_row:
+                o_rows.parent.master_table_cells_copy['row'] += 1
+                o_rows.parent.copied_row += 1
+            o_rows.paste()
         self.check_status_of_right_click_buttons()
         self.main_window.check_master_table_column_highlighting()
 
@@ -795,14 +813,24 @@ class H3TableHandler:
 
     def rows_duplicate(self):
         '''duplicate currently selected rows'''
-        o_table_row = TableRowHandler(main_window=self.main_window)
-        o_table_row.insert_blank_row()
+        # o_table_row = TableRowHandler(main_window=self.main_window)
+        # o_table_row.insert_blank_row()
         o_row = RowsHandler(parent=self.main_window)
         row_selected = o_row.o_selection.top_row
-        o_row.copy(row=row_selected)
-        o_row.paste(row=row_selected - 1)
-        self.check_status_of_right_click_buttons()
-        self.main_window.check_master_table_column_highlighting()
+        msg = "No row(s) selected. Highlight any cell(s) in row(s) to duplicate followed by right click."
+        if not rows_selected_valid([row_selected], msg):
+            self.main_window.ui.statusbar.setStyleSheet("color: red")
+            self.main_window.ui.statusbar.showMessage(msg, self.main_window.statusbar_display_time)
+            return
+        else:
+            o_table_row = TableRowHandler(main_window=self.main_window)
+            o_table_row.insert_blank_row()
+            o_row = RowsHandler(parent=self.main_window)
+            row_selected = o_row.o_selection.top_row
+            o_row.copy(row=row_selected)
+            o_row.paste(row=row_selected - 1)
+            self.check_status_of_right_click_buttons()
+            self.main_window.check_master_table_column_highlighting()
 
     def refresh_table(self):
         '''reload the initial file'''
@@ -896,6 +924,7 @@ class H3TableHandler:
         '''insert a blank row'''
         o_row = TableRowHandler(main_window=self.main_window)
         o_row.insert_blank_row()
+        self.main_window.table_inserted_row = o_row.inserted_row
         self.check_status_of_right_click_buttons()
         self.main_window.check_master_table_column_highlighting()
 

--- a/addie/processing/mantid/master_table/table_tree_handler.py
+++ b/addie/processing/mantid/master_table/table_tree_handler.py
@@ -813,8 +813,6 @@ class H3TableHandler:
 
     def rows_duplicate(self):
         '''duplicate currently selected rows'''
-        # o_table_row = TableRowHandler(main_window=self.main_window)
-        # o_table_row.insert_blank_row()
         o_row = RowsHandler(parent=self.main_window)
         row_selected = o_row.o_selection.top_row
         msg = "No row(s) selected. Highlight any cell(s) in row(s) to duplicate followed by right click."

--- a/addie/processing/mantid/master_table/table_tree_handler.py
+++ b/addie/processing/mantid/master_table/table_tree_handler.py
@@ -75,7 +75,7 @@ class TableInitialization:
 
         _table_config = TableConfig(main_window=self.main_window)
         current_config = _table_config.get_current_config()
-        
+ 
         inside_dict = OrderedDict()
         inside_dict['table'] = current_config
         inside_dict['active'] = False


### PR DESCRIPTION
A single shot aiming at solving multiple issues with table population/manipulation for mantid interface, as detailed below.

1. Fix the bug with fetching information from oncat.

2. When typing in some text in the search box alongside `List of all runs selected`, the table below would be updated accordingly. In this case, we do expect that runs listed explicitly in the table (after the application of the quick filter specified in the search box) are to be imported when clicking on the `Import` button at the bottom. However, this was not the case and here we intend to implement such an expected behavior.

    2.1. The original `Import All Runs` button text is changed to ` Import All Listed Runs`.

    2.2. When clicking on the `Import All Listed Runs`, only runs that are listed explicitly will be imported.

3. Fix several issues with the right click menu in the main ADDIE processing window (the `Mantid` interface).

    3.1. When right click on the white space (i.e. no cells/rows selected), followed by executing copy/paste/duplicate, etc., ADDIE would crash, complaining about index out of range.

    3.2. When selecting the `Show All Columns` option under `Columns Configuration`, ADDIE would crash. The reason for such a crash is that the dictionary for storing the full configuration is not initialized.

    3.3. When a certain row is copied, more robust behavior is expected. For example, after the copy operation, we can insert a new row and paste the copied row into the new blank row. Though this can be realized by simply duplicating a certain row, still the behavior described here is what a normal user would expect, in terms of the copy/paste operations.

4. Little bug fix - some button icons fail to load at first launching.