### PR TITLE
Pin pytest-qt to <= 3.3.0, after that it dropped support for PyQt5<5.11

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
+          mamba-version: "*"
           python-version: ${{ matrix.python-version }} 
           channels: neutrons,conda-forge,mantid,neutrons
 
@@ -37,13 +38,7 @@ jobs:
 
       - name: Conda install deps
         shell: bash -l {0}
-        run: |
-          conda config --remove channels defaults
-          conda install -c conda-forge nexus==4.4.3
-          conda install -c conda-forge poco==1.7.3
-          conda install mantid-workbench
-          conda install mantid-total-scattering-python-wrapper
-          conda install --file requirements.txt --file requirements-dev.txt
+        run: mamba install mantid-workbench mantid-total-scattering-python-wrapper --file requirements.txt --file requirements-dev.txt
 
       - name: Mantid pre-requisites
         shell: bash -l {0}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,5 +2,5 @@ flake8
 mock
 pytest
 pytest-mpl
-pytest-qt
+pytest-qt<=3.3.0
 typing


### PR DESCRIPTION
This fixes the CI and also makes it run so much faster.