### PR TITLE
switch pyoncat to conda channel

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -46,6 +46,7 @@ requirements:
     - python
     - pystog
     - simplejson
+    - pyoncat
 
 test:
   imports:

--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,7 @@ channels:
 - conda-forge
 - neutrons
 - mantid
+- oncat
 dependencies:
 - build
 - configparser
@@ -21,6 +22,4 @@ dependencies:
 - simplejson
 - typing
 - versioningit
-- pip
-- pip:
-    - https://oncat.ornl.gov/packages/pyoncat-1.5.1-py3-none-any.whl
+- pyoncat


### PR DESCRIPTION
This PR introduces the following changes:

- switch source of `pyoncat` from `PyPI` to `conda`